### PR TITLE
Make some char * into const char * to avoid C++ compiler warnings.

### DIFF
--- a/src/confuse.h
+++ b/src/confuse.h
@@ -258,7 +258,7 @@ struct cfg_defvalue_t {
     long int number;        /**< default integer value */
     double fpnumber;        /**< default floating point value */
     cfg_bool_t boolean;     /**< default boolean value */
-    char *string;           /**< default string value */
+    const char *string;     /**< default string value */
     char *parsed;           /**< default value that is parsed by
                              * libConfuse, used for lists and
                              * functions */
@@ -269,7 +269,7 @@ struct cfg_defvalue_t {
  * etc).
  */
 struct cfg_opt_t {
-    char *name;             /**< The name of the option */
+    const char *name;       /**< The name of the option */
     cfg_type_t type;        /**< Type of option */
     unsigned int nvalues;   /**< Number of values parsed */
     cfg_value_t **values;   /**< Array of found values */


### PR DESCRIPTION
This avoids C++ compiler warnings when using libconfuse in C++ programs
and providing a string literal to CFG_zzz macros. It affects config item
names, and also CFG_STR default values.
    CFG_STR("log-config", "log.conf", CFGF_NONE),
warning: deprecated conversion from string constant to ‘char*’

Note that I'm not sure if this is complete. There is also `char * parsed` in
`struct cfg_defvalue_t`, and I guess that should probably be `const` too. But
I don't know for sure because I'm not using that functionality in libconfuse.
