### PR TITLE
Update ISC License to 2007 version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) 2002,2003,2007 Martin Hedenfalk <martin@bzero.se>
 
-Permission to use, copy, modify, and distribute this software for any
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2002,2003,2007 Martin Hedenfalk <martin@bzero.se>
  *
- * Permission to use, copy, modify, and distribute this software for any
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2002,2003,2007 Martin Hedenfalk <martin@bzero.se>
  *
- * Permission to use, copy, modify, and distribute this software for any
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2002,2003,2007 Martin Hedenfalk <martin@bzero.se>
  *
- * Permission to use, copy, modify, and distribute this software for any
+ * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *


### PR DESCRIPTION
```
Before accepting the license as a free software license, the
Free Software Foundation (FSF) asked for clarification of the
text. In July 2007, as a result, "and distribute" was changed
to "and/or distribute".

                  -- http://en.wikipedia.org/wiki/ISC_license
```

Signed-off-by: Joachim Nilsson troglobit@gmail.com
