### PR TITLE
confuse: write to files without leaving spaces around equal sign.

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1647,7 +1647,7 @@ DLLIMPORT void cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent)
                                              opt->values[0]->string[0] == 0)))
                     fprintf(fp, "# ");
             }
-            fprintf(fp, "%s = ", opt->name);
+            fprintf(fp, "%s=", opt->name);
             if(opt->pf)
                 opt->pf(opt, 0, fp);
             else


### PR DESCRIPTION
This allows simplest confuse files to be sourced from bash and
other shells, since they expect the format to be VARIABLE=VALUE
without any spaces.

Signed-off-by: Alvaro G. M. alvaro.gamez@hazent.com
