### PR TITLE
Fix mid-string environment variable substitution

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -182,11 +182,8 @@ static YY_BUFFER_STATE string_scan_state = 0;
 <dq_str>\\.  {
     qputc(yytext[1]);
 }
-<dq_str>[^\\\"\n]+  {
-    char *yptr = yytext;
-    while(*yptr) {
-        qputc(*yptr++);
-    }
+<dq_str>[^\\\"\n]  {
+    qputc(yytext[0]);
 }
 
     /* single-quoted string ('...') */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 TESTS = suite_single suite_dup suite_func suite_list \
 	suite_validate list_plus_syntax section_title_dupes \
 	single_title_sections quote_before_print include \
-	searchpath
+	searchpath env
 check_PROGRAMS=$(TESTS)
 
 LDADD=-L../src ../src/libconfuse.la $(LTLIBINTL)

--- a/tests/env.c
+++ b/tests/env.c
@@ -1,0 +1,70 @@
+/* Test cfg_include when called from a buffer
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include "check_confuse.h"
+
+cfg_opt_t opts[] =
+{
+        CFG_STR("parameter", NULL, CFGF_NONE),
+        CFG_END()
+};
+
+static int
+testconfig(const char *buf, const char *parameter)
+{
+	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+        if (!cfg)
+            return 0;
+
+	if (cfg_parse_buf(cfg, buf) != CFG_SUCCESS)
+            return 0;
+
+        char *param = cfg_getstr(cfg, "parameter");
+        if (!param)
+            return 0;
+
+        if (strcmp(param, parameter) != 0)
+            return 0;
+
+	cfg_free(cfg);
+        return 1;
+}
+
+int
+main(void)
+{
+	fail_unless(setenv("MYVAR", "testing", 1) == 0);
+	fail_unless(unsetenv("MYUNSETVAR") == 0);
+
+        /* Check basic string parsing */
+        fail_unless(testconfig("parameter=\"abc\\ndef\"", "abc\ndef"));
+        fail_unless(testconfig("parameter=\"abc\\adef\"", "abc\adef"));
+        fail_unless(testconfig("parameter=\"abc\\040def\"", "abc def"));
+        fail_unless(testconfig("parameter=\"abc\\x20def\"", "abc def"));
+        fail_unless(testconfig("parameter=\"${}\"", ""));
+
+        /* Check unquoted environment variable handling */
+        fail_unless(testconfig("parameter=${MYVAR}", "testing"));
+        fail_unless(testconfig("parameter=${MYVAR:-default}", "testing"));
+        fail_unless(testconfig("parameter=${MYUNSETVAR}", ""));
+        fail_unless(testconfig("parameter=${MYUNSETVAR:-default}", "default"));
+
+        /* Check quoted environment variable handling */
+        fail_unless(testconfig("parameter=\"${MYVAR}\"", "testing"));
+        fail_unless(testconfig("parameter=\"${MYVAR:-default}\"", "testing"));
+        fail_unless(testconfig("parameter=\"${MYUNSETVAR}\"", ""));
+        fail_unless(testconfig("parameter=\"${MYUNSETVAR:-default}\"", "default"));
+
+        /* Check quoted environment variable handling in the middle of strings */
+        fail_unless(testconfig("parameter=\"text_${MYVAR}\"", "text_testing"));
+        fail_unless(testconfig("parameter=\"${MYVAR}_text\"", "testing_text"));
+        fail_unless(testconfig("parameter=\"start_${MYVAR}_end\"", "start_testing_end"));
+
+        /* Check single quoted environment variable handling */
+        fail_unless(testconfig("parameter='${MYVAR}'", "${MYVAR}"));
+
+	return 0;
+}
+


### PR DESCRIPTION
This change fixes the case where environment substitution did not happen
in the middle of string parameters. For example:

parameter = "sometext/${ENVVAR}"

In this case, ${ENVVAR} was not expanded since the flex rule to match the
whole string took precedence over the flex rule to perform environment
variable substitution. Flex chooses longer matches over shorter matches.
The fix is to modify the normal character matching rule to match one
character at a time.

A unit test was added to verify the fix and check that it didn't break
other string or environment processing.

Signed-off-by: Frank Hunleth fhunleth@troodon-software.com
