### PR TITLE
Add functions to remove sections.

### DIFF
--- a/src/confuse.h
+++ b/src/confuse.h
@@ -1071,6 +1071,50 @@ DLLIMPORT int __export cfg_numopts(cfg_opt_t *opts);
 DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name,
                                     unsigned int nvalues, ...);
 
+/** Removes and frees a config section, given a cfg_opt_t pointer.
+ * @param opt The option structure (eg, as returned from cfg_getopt())
+ * @param index Index of the section to remove. Zero based.
+ * @see cfg_rmnsec
+ */
+DLLIMPORT void __export cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index);
+
+/** Indexed version of cfg_rmsec(), used for CFGF_MULTI sections.
+ * @param cfg The configuration file context.
+ * @param name The name of the section.
+ * @param index Index of the section to remove. Zero based.
+ * @see cfg_rmsec
+ */
+DLLIMPORT void __export cfg_rmnsec(cfg_t *cfg, const char *name,
+                                   unsigned int index);
+
+/** Removes and frees a config section. This is the same as
+ * calling cfg_rmnsec with index 0.
+ * @param cfg The configuration file context.
+ * @param name The name of the section.
+ */
+DLLIMPORT void __export cfg_rmsec(cfg_t *cfg, const char *name);
+
+/** Removes and frees a config section, given a cfg_opt_t pointer
+ * and the title.
+ * @param opt The option structure (eg, as returned from cfg_getopt())
+ * @param title The title of this section. The CFGF_TITLE flag must
+ * have been set for this option.
+ * @see cfg_rmtsec
+ */
+DLLIMPORT void __export cfg_opt_rmtsec(cfg_opt_t *opt, const char *title);
+
+/** Removes and frees a section given the title, used for section with the
+ * CFGF_TITLE flag set.
+ *
+ * @param cfg The configuration file context.
+ * @param name The name of the section.
+ * @param title The title of this section. The CFGF_TITLE flag must
+ * have been set for this option.
+ * @see cfg_rmsec
+ */
+DLLIMPORT void __export cfg_rmtsec(cfg_t *cfg, const char *name,
+                                   const char *title);
+
 /** Default value print function.
  *
  * Print only the value of a given option. Does not handle sections or

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,6 +9,7 @@ TESTS            += suite_validate
 TESTS            += list_plus_syntax
 TESTS            += section_title_dupes
 TESTS            += single_title_sections
+TESTS            += section_remove
 TESTS            += quote_before_print
 TESTS            += include
 TESTS            += searchpath

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,8 +1,19 @@
 EXTRA_DIST        = a.conf b.conf spdir check_confuse.h
-TESTS             = suite_single suite_dup suite_func suite_list	\
-		    suite_validate list_plus_syntax section_title_dupes	\
-		    single_title_sections quote_before_print include	\
-		    searchpath env
+
+TESTS             =
+TESTS            += suite_single
+TESTS            += suite_dup
+TESTS            += suite_func
+TESTS            += suite_list
+TESTS            += suite_validate
+TESTS            += list_plus_syntax
+TESTS            += section_title_dupes
+TESTS            += single_title_sections
+TESTS            += quote_before_print
+TESTS            += include
+TESTS            += searchpath
+TESTS            += env
+
 check_PROGRAMS    = $(TESTS)
 
 DEFS              = -DSRC_DIR='"$(srcdir)"'

--- a/tests/section_remove.c
+++ b/tests/section_remove.c
@@ -1,0 +1,51 @@
+#include "check_confuse.h"
+#include <string.h>
+
+int main(void)
+{
+    static cfg_opt_t section_opts[] = {
+        CFG_STR("prop", 0, CFGF_NONE),
+        CFG_END()
+    };
+
+    cfg_opt_t opts[] = {
+        CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_END()
+    };
+
+    const char *config_data =
+        "section title_one { prop = 'value_one' }\n"
+        "section title_two { prop = 'value_two' }\n"
+        "section title_one { prop = 'value_one' }\n";
+
+    int rc;
+    cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+    fail_unless(cfg);
+
+    rc = cfg_parse_buf(cfg, config_data);
+    fail_unless(rc == CFG_SUCCESS);
+
+    cfg_rmtsec(cfg, "section", "title_two");
+    fail_unless(cfg_size(cfg, "section") == 1);
+    fail_unless(
+	strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_one") == 0);
+
+    cfg_free(cfg);
+
+
+    cfg = cfg_init(opts, CFGF_NONE);
+    fail_unless(cfg);
+
+    rc = cfg_parse_buf(cfg, config_data);
+
+    fail_unless(rc == CFG_SUCCESS);
+
+    cfg_rmsec(cfg, "section");
+    fail_unless(cfg_size(cfg, "section") == 1);
+    fail_unless(
+	strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_two") == 0);
+
+    cfg_free(cfg);
+
+    return 0;
+}


### PR DESCRIPTION
Hi!

I needed to remove sections, so that run-time changes could be seen when printing the config. Is this interesting at all?

Maybe I should free(opt->values) at the end of cfg_opt_rmnsec() if opt->nvalues drops to zero?

Cheers,
Peter
