### PR TITLE
Memory leak fix

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -705,7 +705,12 @@ cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, char *value)
                 val->section->filename = cfg->filename ? strdup(cfg->filename) : 0;
                 val->section->line = cfg->line;
                 val->section->errfunc = cfg->errfunc;
-                val->section->title = value;
+                if (value != NULL) {
+                  val->section->title = strdup(value);
+                }
+                else {
+                  val->section->title = value;
+                }
             }
             if(!is_set(CFGF_DEFINIT, opt->flags))
                 cfg_init_defaults(val->section);
@@ -1011,6 +1016,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level,
                 }
 
                 val = cfg_setopt(cfg, opt, opttitle);
+                free(opttitle);
                 opttitle = 0;
                 if(!val)
                     return STATE_ERROR;
@@ -1304,8 +1310,13 @@ DLLIMPORT void cfg_free_value(cfg_opt_t *opt)
         {
             if(opt->type == CFGT_STR)
                 free(opt->values[i]->string);
-            else if(opt->type == CFGT_SEC)
-                cfg_free(opt->values[i]->section);
+            else if(opt->type == CFGT_SEC) {
+              if (opt->values[i]->section->title != NULL) {
+                free(opt->values[i]->section->title);
+                opt->values[i]->section->title = 0;
+              }
+              cfg_free(opt->values[i]->section);
+            }
             else if(opt->type == CFGT_PTR && opt->freecb && opt->values[i]->ptr)
                 (opt->freecb)(opt->values[i]->ptr);
             free(opt->values[i]);


### PR DESCRIPTION
This fixes a small memory leak where titles to sections are not freed. This references issue #17. It seems to work fine with some of the examples provided, and the test suite completes successfully.

Please forgive the messy commit history, I'm not very good at git rebase.