### PR TITLE
Add support for handling unknown options

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -882,8 +882,12 @@ static int cfg_parse_internal(cfg_t *cfg, int level,
                     return STATE_ERROR;
                 }
                 opt = cfg_getopt(cfg, cfg_yylval);
-                if(opt == 0)
-                    return STATE_ERROR;
+                if(opt == 0) {
+                    if(cfg->flags & CFGF_IGNORE_UNKNOWN)
+                        opt = cfg_getopt(cfg, "__unknown");
+                    if(opt == 0)       
+                        return STATE_ERROR;
+                }
                 if(opt->type == CFGT_SEC)
                 {
                     if(is_set(CFGF_TITLE, opt->flags))

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -90,6 +90,7 @@ typedef enum cfg_type_t cfg_type_t;
 
 #define CFGF_RESET 64
 #define CFGF_DEFINIT 128
+#define CFGF_IGNORE_UNKNOWN 256 /**< ignore unknown options in configuration files */
 
 /** Return codes from cfg_parse(). */
 #define CFG_SUCCESS 0
@@ -544,10 +545,15 @@ extern const char __export confuse_author[];
  *
  * The options must no longer be defined in the same scope as where the cfg_xxx
  * functions are used (since version 2.3). 
+ * 
+ * CFG_IGNORE_UNKNOWN can be specified to use the "__unknown" option
+ * whenever an unknown option is parsed. Be sure to define an "__unknown"
+ * option in each scope that unknown parameters are allowed.
  *
  * @param opts An arrary of options
  * @param flags One or more flags (bitwise or'ed together). Currently only
- * CFGF_NOCASE is available. Use 0 if no flags are needed.
+ * CFGF_NOCASE and CFGF_IGNORE_UNKNOWN are available. Use 0 if no flags are
+ * needed.
  *
  * @return A configuration context structure. This pointer is passed
  * to almost all other functions as the first parameter.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 TESTS = suite_single suite_dup suite_func suite_list \
 	suite_validate list_plus_syntax section_title_dupes \
 	single_title_sections quote_before_print include \
-	searchpath env
+	searchpath env ignore_parm
 check_PROGRAMS=$(TESTS)
 
 LDADD=-L../src ../src/libconfuse.la $(LTLIBINTL)

--- a/tests/ignore_parm.c
+++ b/tests/ignore_parm.c
@@ -1,0 +1,64 @@
+/* Test handling of parameters that should be ignored.
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include "check_confuse.h"
+
+cfg_opt_t section_opts[] =
+{
+	CFG_STR("section_parameter", NULL, CFGF_NONE),
+	CFG_STR("__unknown", NULL, CFGF_NONE),
+	CFG_END()
+};
+
+cfg_opt_t opts[] =
+{
+	CFG_STR("parameter", NULL, CFGF_NONE),
+	CFG_STR("__unknown", NULL, CFGF_NONE),
+	CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
+	CFG_END()
+};
+
+static int
+testconfig(const char *buf)
+{
+	cfg_t *cfg = cfg_init(opts, CFGF_IGNORE_UNKNOWN);
+	if (!cfg)
+		return 0;
+
+	if (cfg_parse_buf(cfg, buf) != CFG_SUCCESS)
+		return 0;
+
+	cfg_free(cfg);
+	return 1;
+}
+
+int
+main(void)
+{
+	/* Sanity check cases that don't need to ignore parameters. */
+	fail_unless(testconfig("parameter=5"));
+	fail_unless(testconfig("parameter=5\n"
+				"section mysection {\n"
+				"section_parameter=1\n"
+				"}"));
+
+	/* Ignore each type (no lists) */
+	fail_unless(testconfig("unknown_int=1"));
+	fail_unless(testconfig("unknown_string=\"hello\""));
+	fail_unless(testconfig("unknown_float=1.1"));
+	fail_unless(testconfig("unknown_bool=true"));
+
+	/* Ignore multiple parameters */
+	fail_unless(testconfig("unknown_one=1\n"
+				"unknown_two=2\n"
+				"unknown_three=3\n"));
+
+	/* Test ignore parameters in a section */
+	fail_unless(testconfig("section mysection {\n"
+				"unknown_section_parameter=1\n"
+				"}"));
+	return 0;
+}
+


### PR DESCRIPTION
Unknown options can be any of the basic types. Lists won't work.
The purpose is to provide some future proofing of config files.
For example, if a new parameter is added to a program, the new
config files won't necessarily fail when run against old versions
of the program.

Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>