### PR TITLE
Update Makefile to fix lexer variable prefixes.

### DIFF
--- a/windows/mingw/Makefile
+++ b/windows/mingw/Makefile
@@ -3,6 +3,7 @@ AR=i686-pc-mingw32-ar
 SRCDIR=../../src
 VPATH=$(SRCDIR)
 INCLUDE=-I. -I$(SRCDIR)
+LFLAGS=-Pcfg_yy
 CFLAGS=-Wall -DHAVE_CONFIG_H $(INCLUDE)
 ARFLAGS=rc
 


### PR DESCRIPTION
I probably could've used ./configure to prevent this, but...

The lexer expects lex variables to be prefixed with cfg_yy, otherwise a number of undefined references will occur when compiling lexer.c. Add LFLAGS variable to ensure GNU Make runs lex with the extra required options.