### PR TITLE
Get rid of the README symbolic link.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -15,8 +15,8 @@ reconfiguring, and a file `config.log' containing compiler output
 
    If you need to do unusual things to compile the package, please try
 to figure out how `configure' could check whether to do them, and mail
-diffs or instructions to the address given in the `README' so they can
-be considered for the next release.  If at some point `config.cache'
+diffs or instructions to the address given in the `README.md' so they
+can be considered for the next release.  If at some point `config.cache'
 contains results you don't want to keep, you may remove or edit it.
 
    The file `configure.in' is used to create `configure' by a program
@@ -111,8 +111,8 @@ Optional Features
 `configure', where FEATURE indicates an optional part of the package.
 They may also pay attention to `--with-PACKAGE' options, where PACKAGE
 is something like `gnu-as' or `x' (for the X Window System).  The
-`README' should mention any `--enable-' and `--with-' options that the
-package recognizes.
+`README.md' should mention any `--enable-' and `--with-' options that
+the package recognizes.
 
    For packages that use the X Window System, `configure' can usually
 find the X include and library files automatically, but if it doesn't,

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 AUTOMAKE_OPTIONS = foreign
 CLEANFILES       = *~ '\#*\#'
-doc_DATA         = README AUTHORS LICENSE ChangeLog
+doc_DATA         = README.md AUTHORS LICENSE ChangeLog
 EXTRA_DIST       = libconfuse.spec.in libconfuse.spec
 
 EXAMPLES =

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.md

--- a/libconfuse.spec.in
+++ b/libconfuse.spec.in
@@ -88,7 +88,7 @@ cp -R doc/man/* "${RPM_BUILD_ROOT}%{_mandir}/"
 
 %{__mkdir_p} "${RPM_BUILD_ROOT}%{_pkgdoc}"
 echo -n > _rpm_doc_files_
-for f in AUTHORS LICENSE ChangeLog README; do
+for f in AUTHORS LICENSE ChangeLog README.md; do
 	%{__cp} "$f" "${RPM_BUILD_ROOT}%{_pkgdoc}/$f"
 	echo "%doc %{_pkgdoc}/$f" >> _rpm_doc_files_
 done


### PR DESCRIPTION
This pull request deletes the symbolic link from README to README.md.  It you merge this in, it would be easier for those of us using Windows and MSYS2 to build the library.  You can't create a symbolic link to a file that does not exist in Windows, so when I try to extract the tar archive (using MSYS2's tar utility), this is what happens:

~~~~
$ wget https://github.com/martinh/libconfuse/archive/master.tar.gz
$ tar -xf master.tar.gz
tar: libconfuse-master/README: Cannot create symlink to ‘README.md’: No such file or directory
tar: Exiting with failure status due to previous errors
~~~~

I am sure there are workarounds we could use, but it would be nice if we didn't have to.  And I suppose that when you release a tarball for the next version of the library, it probably won't have a symbolic link it, so maybe it's not a big deal if the git repository has one.

Thanks!
