### PR TITLE
Allow cfg_opt_getval on options that are CFGF_MULTI sections.

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1383,7 +1383,7 @@ static cfg_value_t *cfg_opt_getval(cfg_opt_t *opt, unsigned int index)
 {
     cfg_value_t *val = 0;
 
-    assert(index == 0 || is_set(CFGF_LIST, opt->flags));
+    assert(index == 0 || is_set(CFGF_LIST, opt->flags) || is_set(CFGF_MULTI, opt->flags));
 
     if(opt->simple_value.ptr)
         val = (cfg_value_t *)opt->simple_value.ptr;


### PR DESCRIPTION
I wrote a test for the section removal code in that other pull request and ran the testsuite for the first time and noticed that cfg_opt_getval asserts on multi-sections...

I came up with this fix.

Cheers,
Peter