### PR TITLE
Fixes to tests to support mingw-w64 (Windows)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AC_CHECK_HEADERS([sys/stat.h])
 AC_C_CONST
 
 # Checks for library functions.
-AC_CHECK_FUNCS([strcasecmp strdup strndup])
+AC_CHECK_FUNCS([strcasecmp strdup strndup setenv unsetenv _putenv])
 
 dnl Check for the library containing inet_aton/inet_ntoa (for tests)
 AC_SEARCH_LIBS([inet_ntoa], [socket nsl])

--- a/tests/env.c
+++ b/tests/env.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "check_confuse.h"
+#include "config.h"
 
 cfg_opt_t opts[] =
 {
@@ -35,8 +36,15 @@ testconfig(const char *buf, const char *parameter)
 int
 main(void)
 {
+#if defined(HAVE_SETENV) && defined(HAVE_UNSETENV)
 	fail_unless(setenv("MYVAR", "testing", 1) == 0);
 	fail_unless(unsetenv("MYUNSETVAR") == 0);
+#elif defined(HAVE__PUTENV)
+	fail_unless(_putenv("MYVAR=testing") == 0);
+	fail_unless(_putenv("MYUNSETVAR=") == 0);
+#else
+#error "Not sure how to set environment variables."
+#endif
 
         /* Check basic string parsing */
         fail_unless(testconfig("parameter=\"abc\\ndef\"", "abc\ndef"));

--- a/tests/suite_func.c
+++ b/tests/suite_func.c
@@ -1,9 +1,6 @@
 #include "check_confuse.h"
 #include <string.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 
 void suppress_errors(cfg_t *cfg, const char *fmt, va_list ap);
 

--- a/tests/suite_validate.c
+++ b/tests/suite_validate.c
@@ -2,9 +2,6 @@
 #include "check_confuse.h"
 #include <string.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 
 static cfg_t *cfg = 0;
 
@@ -49,16 +46,23 @@ int validate_speed(cfg_t *cfg, cfg_opt_t *opt)
 
 int validate_ip(cfg_t *cfg, cfg_opt_t *opt)
 {
-    unsigned int i;
+    unsigned int i, j;
 
     for(i = 0; i < cfg_opt_size(opt); i++)
     {
-        struct in_addr addr;
+        unsigned int v[4];
         char *ip = cfg_opt_getnstr(opt, i);
-        if(inet_aton(ip, &addr) == 0)
+        if (sscanf(ip, "%u.%u.%u.%u", v + 0, v + 1, v + 2, v + 3) != 4)
         {
             /* cfg_error(cfg, "invalid IP address %s in section %s", ip, cfg->name); */
             return 1;
+        }
+        for (j = 0; j < 4; j++)
+        {
+            if (v[j] > 0xff)
+            {
+                return 1;
+            }
         }
     }
     return 0;

--- a/windows/borland/config.h
+++ b/windows/borland/config.h
@@ -83,3 +83,12 @@
 
 /* Define to 1 if you have the strndup function */
 /*#undef HAVE_STRNDUP */
+
+/* Define to 1 if you have the `setenv' function. */
+/* #undef HAVE_SETENV */
+
+/* Define to 1 if you have the `unsetenv' function. */
+/* #undef HAVE_UNSETENV */
+
+/* Define to 1 if you have the `_putenv' function. */
+#define HAVE__PUTENV 1

--- a/windows/devcpp/config.h
+++ b/windows/devcpp/config.h
@@ -84,3 +84,11 @@
 /* Define to 1 if you have the strndup function */
 /*#undef HAVE_STRNDUP */
 
+/* Define to 1 if you have the `setenv' function. */
+/* #undef HAVE_SETENV */
+
+/* Define to 1 if you have the `unsetenv' function. */
+/* #undef HAVE_UNSETENV */
+
+/* Define to 1 if you have the `_putenv' function. */
+#define HAVE__PUTENV 1

--- a/windows/mingw/config.h
+++ b/windows/mingw/config.h
@@ -83,3 +83,12 @@
 
 /* Define to 1 if you have the strndup function */
 /*#undef HAVE_STRNDUP */
+
+/* Define to 1 if you have the `setenv' function. */
+/* #undef HAVE_SETENV */
+
+/* Define to 1 if you have the `unsetenv' function. */
+/* #undef HAVE_UNSETENV */
+
+/* Define to 1 if you have the `_putenv' function. */
+#define HAVE__PUTENV 1

--- a/windows/msvc6/libConfuse/config.h
+++ b/windows/msvc6/libConfuse/config.h
@@ -92,3 +92,12 @@
 
 /* Define if you have _isatty but not isatty */
 #define HAVE__ISATTY 1
+
+/* Define to 1 if you have the `setenv' function. */
+/* #undef HAVE_SETENV */
+
+/* Define to 1 if you have the `unsetenv' function. */
+/* #undef HAVE_UNSETENV */
+
+/* Define to 1 if you have the `_putenv' function. */
+#define HAVE__PUTENV 1

--- a/windows/msvs.net/config.h
+++ b/windows/msvs.net/config.h
@@ -92,3 +92,12 @@
 
 /* Define if you have _isatty but not isatty */
 #define HAVE__ISATTY 1
+
+/* Define to 1 if you have the `setenv' function. */
+/* #undef HAVE_SETENV */
+
+/* Define to 1 if you have the `unsetenv' function. */
+/* #undef HAVE_UNSETENV */
+
+/* Define to 1 if you have the `_putenv' function. */
+#define HAVE__PUTENV 1


### PR DESCRIPTION
This pull request fixes all the tests that were failing because of differences between mingw-w64 (a GCC compiler for Windows) and Linux.  When I combined this pull request with pull request #27, I got all the tests to pass in MSYS2.