### PR TITLE
Add support for Travis-CI and Coverity Scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Travis CI integration
+# Defaults to GNU GCC and autotools: ./configure && make && make test
+language: c
+
+# We need to install autopoint, so we cannot use dockerized build
+sudo: true
+
+env:
+  global:
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+   - secure: "kFrbrFEPt+f2UTSoKymheDJiLOcuXqvCDeV8EqCIsQT7oMpwHxLogJio3BIAUfP9Ykm73roJPKOt5YVv6k8IGDvKuR5XOJDl4gfLM8S1L9shGuQwk8E7nC3/96IoVRnkuqsWseDbHBm/K6jV6TRIVRVyc4Dcbjdb7qBTuVF5VNE="
+
+addons:
+  coverity_scan:
+    project:
+      name: "troglobit/libconfuse"
+      description: "Small configuration file parser library for C"
+    notification_email: troglobit@gmail.com
+    build_command_prepend: "sudo apt-get install autopoint && ./autogen.sh"
+    build_command:   "make check"
+    branch_pattern: master
+
+# We don't store generated files (configure and Makefile) in GIT,
+# so we must customize the default build script to run ./autogen.sh
+script:
+  - sudo apt-get install autopoint
+  - ./autogen.sh
+  - ./configure
+  - make
+  - make check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 libConfuse
 ==========
+[![Travis Status][]][Travis] [![Coverity Status][]][Coverity Scan]
 
 Table of Contents
 -----------------
@@ -125,3 +126,14 @@ News
 ----
 
 Copyright &copy; Martin Hedenfalk <[martin.nospam@bzero.se](mailto:martin@bzero.se)>
+
+[Travis]:           https://travis-ci.org/troglobit/libconfuse
+[Travis Status]:    https://travis-ci.org/troglobit/libconfuse.png?branch=master
+[Coverity Scan]:    https://scan.coverity.com/projects/6674
+[Coverity Status]:  https://scan.coverity.com/projects/6674/badge.svg
+
+<!--
+  -- Local Variables:
+  -- mode: markdown
+  -- End:
+  -->

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,29 +1,8 @@
 #!/bin/sh
+# (Re)Generate configure script and all build related files for i18n
 
-echo -n "Running autopoint..."
-autopoint && echo " done"
+autoreconf -W portability -vism >/dev/null
+
+# Cleanup
 rm -f ABOUT-NLS
-
-echo -n "Running aclocal..."
-aclocal -I m4 || exit
-echo " done"
-
-echo -n "Running autoconf..."
-autoconf || exit
-echo " done"
-
-echo -n "Running autoheader..."
-autoheader || exit
-echo " done"
-
-echo -n "Running libtoolize..."
-libtoolize --automake || glibtoolize --automake || exit
-echo " done"
-
-echo -n "Running automake..."
-automake --add-missing || exit
-echo " done"
-
-echo "Running configure $*..."
-./configure --enable-maintainer-mode $*
 


### PR DESCRIPTION
This patch set adds support for Travis-CI, automatic builds at checkin,
and Coverity Scan for static code analysis.  It also contains a refactor
of the autogen.sh script to rely on autoreconf instead of calling each
autotool manually.