### PR TITLE
PowerShell script for AppVeyor/MSYS2

### DIFF
--- a/windows/appveyor/msys2-build.ps1
+++ b/windows/appveyor/msys2-build.ps1
@@ -1,0 +1,26 @@
+$prepare = @"
+./autogen.sh
+"@
+
+$build = @"
+mkdir build-`$MINGW_CHOST
+cd build-`$MINGW_CHOST
+../configure --prefix=`$MINGW_PREFIX \
+  --build=`$MINGW_CHOST --host=`$MINGW_CHOST \
+  --enable-static --enable-shared --disable-examples
+make check
+"@
+
+$env:CHERE_INVOKING = "1"
+$env:MSYSTEM = "MINGW64"
+C:/msys64/usr/bin/bash -e -l -c $prepare
+
+$env:MSYSTEM = "MINGW64"
+$env:MINGW_PREFIX = "/mingw64"
+$env:MINGW_CHOST = "x86_64-w64-mingw32"
+C:/msys64/usr/bin/bash -e -l -c $build
+
+$env:MSYSTEM = "MINGW32"
+$env:MINGW_PREFIX = "/mingw32"
+$env:MINGW_CHOST = "i686-w64-mingw32"
+C:/msys64/usr/bin/bash -e -l -c $build


### PR DESCRIPTION
I am thinking it would be nice to set up AppVeyor to automatically build and test the library with MSYS2 in Windows whenever the martinh master branch is updated.  We have to tell AppVeyor what commands to run, and those commands can either be in the form of an MsBuild project, a PowerShell script, or a Batch script.  This pull request adds an appropriate PowerShell script.

This PowerShell script doesn't necessarily have to be in the repository; you could choose to just copy and paste it into the web interface of AppVeyor instead.  However, putting it in the repository allows us to keep track of its version history and makes it easier for others to use it.

AppVeyor actually has MSYS2 installed by default, so we don't need to do any work to install MSYS2.

Here is an example of the build output that this script would generate:

https://ci.appveyor.com/project/DavidEGrayson/libconfuse/build/1.1.35