### PR TITLE
configure.ac: Get rid of unneeded tests for internet-related functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,9 +46,6 @@ AC_C_CONST
 # Checks for library functions.
 AC_CHECK_FUNCS([strcasecmp strdup strndup setenv unsetenv _putenv])
 
-dnl Check for the library containing inet_aton/inet_ntoa (for tests)
-AC_SEARCH_LIBS([inet_ntoa], [socket nsl])
-
 AC_CONFIG_FILES([Makefile \
 		 src/Makefile \
 		 examples/Makefile \


### PR DESCRIPTION
These checks are slow and no longer needed since we simplified the tests.