### PR TITLE
Add cfg_setmulti and cfg_opt_setmulti.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST      = simple.conf reread.conf ftp.conf test.conf
-noinst_PROGRAMS = simple reread ftpconf cfgtest
+noinst_PROGRAMS = simple reread ftpconf cfgtest cli
 AM_CPPFLAGS     = -I$(top_srcdir)/src
 AM_LDFLAGS      = -L../src/
 LIBS            = $(LTLIBINTL)

--- a/examples/cli.c
+++ b/examples/cli.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2015 Peter Rosin <peda@lysator.liu.se>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include "confuse.h"
+
+static cfg_t *cfg;
+static int cmdc;
+static char **cmdv;
+static int cmdv_max;
+
+static int
+reserve_cmdv(int cmdc)
+{
+	int cmd_max = cmdv_max;
+	char **tmp;
+
+	if (cmdc < cmd_max)
+		return 0;
+
+	do
+		cmd_max += 10;
+	while (cmdc >= cmd_max);
+
+	tmp = realloc(cmdv, cmd_max * sizeof(*tmp));
+	if (!tmp)
+		return -1;
+
+	cmdv = tmp;
+	cmdv_max = cmd_max;
+	return 0;
+}
+
+static int
+split_cmd(char *cmd)
+{
+	char *out = cmd;
+	int arg;
+
+	cmdc = 0;
+
+	for (;;) {
+		char ch;
+		arg = 0;
+		while (*cmd == ' ')
+			++cmd;
+next_char:
+		ch = *cmd++;
+		if (ch == '"' || ch == '\'') {
+			char end = ch;
+			if (!arg) {
+				if (reserve_cmdv(cmdc + 1))
+					return -1;
+				cmdv[cmdc++] = out;
+				arg = 1;
+			}
+			while (*cmd && *cmd != end)
+				*out++ = *cmd++;
+			if (!*cmd++)
+				return -1;
+			goto next_char;
+		}
+		if (ch && ch != ' ') {
+			if (!arg) {
+				if (reserve_cmdv(cmdc + 1))
+					return -1;
+				cmdv[cmdc++] = out;
+				arg = 1;
+			}
+			*out++ = ch;
+			goto next_char;
+		}
+		*out++ = 0;
+		if (!ch)
+			break;
+	}
+	return cmdc;
+}
+
+static char *
+input_cmd(void)
+{
+	int ch;
+	char *cmd = malloc(128);
+	int len = 128;
+	int pos = 0;
+
+	if (!cmd)
+		return NULL;
+
+	for (;;) {
+		ch = fgetc(stdin);
+		if (ch < 0)
+			break;
+		switch (ch) {
+		case '\r':
+		case '\n':
+			ch = 0;
+			/* fall through */
+		default:
+			if (pos == len) {
+				char *tmp = realloc(cmd, len * 2);
+				if (!tmp)
+					goto cleanup;
+				cmd = tmp;
+				len *= 2;
+			}
+			cmd[pos++] = ch;
+			if (!ch)
+				return cmd;
+		}
+	}
+cleanup:
+	free(cmd);
+	return NULL;
+}
+
+static const char *
+help(int argc, char *argv[])
+{
+	return
+"available commands:\n"
+"\n"
+"help\n"
+"set <option> <value> ...\n"
+"subset <section> <option> <value>\n"
+"create <section>\n"
+"destroy <section>\n"
+"dump\n"
+"quit\n"
+"\n"
+"<option> is one of 'bool', 'int' 'string' and 'float'.\n";
+}
+
+static const char *
+set(int argc, char *argv[])
+{
+	if (argc < 3)
+		return "Need more args\n";
+
+	if (!cfg_getopt(cfg, argv[1]))
+		return "Unknown option\n";
+
+	if (cfg_setmulti(cfg, argv[1], argc - 2, &argv[2]))
+		return "Failure\n";
+
+	return "OK\n";
+}
+
+static const char *
+subset(int argc, char *argv[])
+{
+	cfg_t *sub;
+
+	if (argc < 4)
+		return "Need more args\n";
+	if (argc > 4)
+		return "Too many args\n";
+
+	sub = cfg_gettsec(cfg, "sub", argv[1]);
+	if (!sub)
+		return "No such section\n";
+
+	if (!cfg_getopt(sub, argv[2]))
+		return "Unknown option\n";
+
+	if (cfg_setmulti(sub, argv[2], argc - 3, &argv[3]))
+		return "Failure\n";
+
+	return "OK\n";
+}
+
+static const char *
+create(int argc, char *argv[])
+{
+	char *buf;
+
+	if (argc != 2)
+		return "Need one arg\n";
+
+	if (cfg_gettsec(cfg, "sub", argv[1]))
+		return "Section exists already\n";
+
+	buf = malloc(strlen(argv[1]) + 20);
+	if (!buf)
+		return NULL;
+
+	sprintf(buf, "sub %s {}\n", argv[1]);
+	if (cfg_parse_buf(cfg, buf) != CFG_SUCCESS)
+		return "Failure\n";
+
+	return "OK\n";
+}
+
+static const char *
+destroy(int argc, char *argv[])
+{
+	if (argc < 2)
+		return "Need one arg\n";
+
+	if (!cfg_gettsec(cfg, "sub", argv[1]))
+		return "No such section\n";
+
+	cfg_rmtsec(cfg, "sub", argv[1]);
+	return "OK\n";
+}
+
+static const char *
+dump(int argc, char *argv[])
+{
+	cfg_print(cfg, stdout);
+	return "";
+}
+
+static const char *
+quit(int argc, char *argv[])
+{
+	return NULL;
+}
+
+struct cmd_handler {
+	const char *cmd;
+	const char *(*handler)(int argc, char *argv[]);
+};
+
+static const struct cmd_handler cmds[] = {
+	{ "help", help },
+	{ "set", set },
+	{ "subset", subset },
+	{ "create", create },
+	{ "destroy", destroy },
+	{ "dump", dump },
+	{ "quit", quit },
+	{ "exit", quit },
+	{ NULL, NULL }
+};
+
+int main(void)
+{
+	cfg_opt_t sub_opts[] = {
+		CFG_BOOL("bool", cfg_false, CFGF_NONE),
+		CFG_STR("string", NULL, CFGF_NONE),
+		CFG_INT("int", 0, CFGF_NONE),
+		CFG_FLOAT("float", 0.0, CFGF_NONE),
+		CFG_END()
+	};
+
+	cfg_opt_t opts[] = {
+		CFG_BOOL_LIST("bool", cfg_false, CFGF_NONE),
+		CFG_STR_LIST("string", NULL, CFGF_NONE),
+		CFG_INT_LIST("int", 0, CFGF_NONE),
+		CFG_FLOAT_LIST("float", "0.0", CFGF_NONE),
+		CFG_SEC("sub", sub_opts,
+			CFGF_MULTI | CFGF_TITLE | CFGF_NO_TITLE_DUPES),
+		CFG_END()
+	};
+
+	char *cmd = NULL;
+	const char *reply;
+	int res;
+	int i;
+
+	cfg = cfg_init(opts, CFGF_NONE);
+
+	for (;;) {
+		printf("cli> ");
+		fflush(stdout);
+
+		if (cmd)
+			free(cmd);
+		cmd = input_cmd();
+		if (!cmd)
+			exit(0);
+		res = split_cmd(cmd);
+		if (res < 0) {
+			printf("Parse error\n");
+			continue;
+		}
+		if (cmdc == 0)
+			continue;
+		for (i = 0; cmds[i].cmd; ++i) {
+			if (strcmp(cmdv[0], cmds[i].cmd))
+				continue;
+			reply = cmds[i].handler(cmdc, cmdv);
+			if (!reply)
+				exit(0);
+			printf("%s", reply);
+			break;
+		}
+		if (!cmds[i].cmd)
+			printf("Unknown command\n");
+	}
+
+	cfg_free(cfg);
+	return 0;
+}

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -752,6 +752,42 @@ cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
     return val;
 }
 
+DLLIMPORT int
+cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues, char **values)
+{
+    cfg_opt_t old;
+    unsigned int i;
+
+    if(!opt || !nvalues)
+        return -1;
+
+    old = *opt;
+    opt->nvalues = 0;
+    opt->values = 0;
+
+    for(i = 0; i < nvalues; i++) {
+        if(cfg_setopt(cfg, opt, values[i]))
+            continue;
+        /* ouch, revert */
+        cfg_free_value(opt);
+        opt->nvalues = old.nvalues;
+        opt->values = old.values;
+        return -1;
+    }
+
+    cfg_free_value(&old);
+    return 0;
+}
+
+DLLIMPORT int
+cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, char **values)
+{
+    cfg_opt_t *opt = cfg_getopt(cfg, name);
+    if(!opt)
+        return -1;
+    return cfg_opt_setmulti(cfg, opt, nvalues, values);
+}
+
 /* searchpath */
 
 struct cfg_searchpath_t {

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -1077,6 +1077,32 @@ DLLIMPORT int __export cfg_numopts(cfg_opt_t *opts);
 DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name,
                                     unsigned int nvalues, ...);
 
+/** Set an option (create an instance of an option).
+ *
+ * @param cfg The configuration file context.
+ * @param opt The option definition.
+ * @param nvalues The number of values to set for the option.
+ * @param values The value(s) for the option.
+ *
+ * @return Returns 0 if the option values where set correctly,
+ * or -1 if an error occurred.
+ */
+DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt,
+			       unsigned int nvalues, char **values);
+
+/** Set an option (create an instance of an option).
+ *
+ * @param cfg The configuration file context.
+ * @param name The name of the option.
+ * @param nvalues The number of values to set for the option.
+ * @param values The value(s) for the option.
+ *
+ * @return Returns 0 if the option values where set correctly,
+ * or -1 if an error occurred.
+ */
+DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name,
+			   unsigned int nvalues, char **values);
+
 /** Removes and frees a config section, given a cfg_opt_t pointer.
  * @param opt The option structure (eg, as returned from cfg_getopt())
  * @param index Index of the section to remove. Zero based.

--- a/tests/suite_list.c
+++ b/tests/suite_list.c
@@ -52,6 +52,7 @@ static void list_teardown(void)
 static void list_string_test(void)
 {
     char *buf;
+    char *multi[2];
 
     fail_unless(cfg_size(cfg, "string") == 3);
     fail_unless(cfg_opt_size(cfg_getopt(cfg, "string")) == 3);
@@ -81,11 +82,19 @@ static void list_string_test(void)
     fail_unless(cfg_size(cfg, "string") == 5);
     fail_unless(strcmp(cfg_getnstr(cfg, "string", 3), "gaz") == 0);
     fail_unless(strcmp(cfg_getnstr(cfg, "string", 4), "onk") == 0);
+
+    multi[0] = "bar";
+    multi[1] = "foo";
+    fail_unless(cfg_setmulti(cfg, "string", 2, multi) == 0);
+    fail_unless(cfg_size(cfg, "string") == 2);
+    fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "bar") == 0);
+    fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "foo") == 0);
 }
 
 static void list_integer_test(void)
 {
     char *buf;
+    char *multi[3];
 
     fail_unless(cfg_size(cfg, "integer") == 2);
     fail_unless(cfg_opt_size(cfg_getopt(cfg, "integer")) == 2);
@@ -113,11 +122,27 @@ static void list_integer_test(void)
     fail_unless(cfg_size(cfg, "integer") == 5);
     fail_unless(cfg_getnint(cfg, "integer", 3) == -1234567890);
     fail_unless(cfg_getnint(cfg, "integer", 4) == 1234567890);
+
+    multi[0] = "42";
+    multi[1] = "17";
+    fail_unless(cfg_setmulti(cfg, "integer", 2, multi) == 0);
+    fail_unless(cfg_size(cfg, "integer") == 2);
+    fail_unless(cfg_getnint(cfg, "integer", 0) == 42);
+    fail_unless(cfg_getnint(cfg, "integer", 1) == 17);
+
+    multi[0] = "17";
+    multi[1] = "bad";
+    multi[2] = "42";
+    fail_unless(cfg_setmulti(cfg, "integer", 3, multi) == -1);
+    fail_unless(cfg_size(cfg, "integer") == 2);
+    fail_unless(cfg_getnint(cfg, "integer", 0) == 42);
+    fail_unless(cfg_getnint(cfg, "integer", 1) == 17);
 }
 
 static void list_float_test(void)
 {
     char *buf;
+    char *multi[3];
 
     fail_unless(cfg_size(cfg, "float") == 1);
     fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 1);
@@ -151,11 +176,27 @@ static void list_float_test(void)
     fail_unless(cfg_size(cfg, "float") == 4);
     fail_unless(cfg_getnfloat(cfg, "float", 2) == 64.64);
     fail_unless(cfg_getnfloat(cfg, "float", 3) == 1234.567890);
+
+    multi[0] = "42";
+    multi[1] = "0.17";
+    fail_unless(cfg_setmulti(cfg, "float", 2, multi) == 0);
+    fail_unless(cfg_size(cfg, "float") == 2);
+    fail_unless(cfg_getnfloat(cfg, "float", 0) == 42);
+    fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.17);
+
+    multi[0] = "42";
+    multi[1] = "bad";
+    multi[2] = "0.17";
+    fail_unless(cfg_setmulti(cfg, "float", 3, multi) == -1);
+    fail_unless(cfg_size(cfg, "float") == 2);
+    fail_unless(cfg_getnfloat(cfg, "float", 0) == 42);
+    fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.17);
 }
 
 static void list_bool_test(void)
 {
     char *buf;
+    char *multi[3];
 
     fail_unless(cfg_size(cfg, "bool") == 6);
     fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 6);
@@ -196,6 +237,21 @@ static void list_bool_test(void)
     fail_unless(cfg_size(cfg, "bool") == 6);
     fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_false);
     fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_false);
+
+    multi[0] = "true";
+    multi[1] = "no";
+    fail_unless(cfg_setmulti(cfg, "bool", 2, multi) == 0);
+    fail_unless(cfg_size(cfg, "bool") == 2);
+    fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
+    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
+
+    multi[0] = "false";
+    multi[1] = "maybe";
+    multi[2] = "yes";
+    fail_unless(cfg_setmulti(cfg, "bool", 3, multi) == -1);
+    fail_unless(cfg_size(cfg, "bool") == 2);
+    fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
+    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
 }
 
 static void list_section_test(void)

--- a/tests/suite_single.c
+++ b/tests/suite_single.c
@@ -155,6 +155,9 @@ void single_string_test(void)
     fail_unless(strcmp(cfg_getstr(cfg, "string"), "set") == 0);
     cfg_setstr(cfg, "string", "manually set");
     fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually set") == 0);
+    buf = "multi set";
+    fail_unless(cfg_setmulti(cfg, "string", 1, &buf) == 0);
+    fail_unless(strcmp(cfg_getstr(cfg, "string"), "multi set") == 0);
 }
 
 void single_integer_test(void)
@@ -171,6 +174,12 @@ void single_integer_test(void)
     fail_unless(cfg_getint(cfg, "integer") == -46);
     cfg_setint(cfg, "integer", 999999);
     fail_unless(cfg_getint(cfg, "integer") == 999999);
+    buf = "42";
+    fail_unless(cfg_setmulti(cfg, "integer", 1, &buf) == 0);
+    fail_unless(cfg_getint(cfg, "integer") == 42);
+    buf = "ouch";
+    fail_unless(cfg_setmulti(cfg, "integer", 1, &buf) == -1);
+    fail_unless(cfg_getint(cfg, "integer") == 42);
 }
 
 void single_float_test(void)
@@ -187,6 +196,12 @@ void single_float_test(void)
     fail_unless(cfg_getfloat(cfg, "float") == -46.777);
     cfg_setfloat(cfg, "float", 5.1234e2);
     fail_unless(cfg_getfloat(cfg, "float") == 5.1234e2);
+    buf = "4.2";
+    fail_unless(cfg_setmulti(cfg, "float", 1, &buf) == 0);
+    fail_unless(cfg_getfloat(cfg, "float") == 4.2);
+    buf = "ouch";
+    fail_unless(cfg_setmulti(cfg, "float", 1, &buf) == -1);
+    fail_unless(cfg_getfloat(cfg, "float") == 4.2);
 }
 
 void single_bool_test(void)
@@ -220,6 +235,13 @@ void single_bool_test(void)
     fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
     cfg_setbool(cfg, "bool", cfg_false);
     fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+
+    buf = "true";
+    fail_unless(cfg_setmulti(cfg, "bool", 1, &buf) == 0);
+    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+    buf = "later";
+    fail_unless(cfg_setmulti(cfg, "bool", 1, &buf) == -1);
+    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
 }
 
 void single_section_test(void)


### PR DESCRIPTION
No PR in sight, that can't be right :-)

From the commit message:

Consider that you have a command line parser, and have parsed a line into
tokens. It turns out that the first token, the command, is a
'set-cfg-variable' type of command and that the other tokens describe
the new value, and possibly what variable to set.

I.e. you are given a command "set foo-list bar gazonk zilch"

and as a response to this command you want to set the "foo-list" option
to { "bar", "gazonk", "zilch" }. There is no current API to do this in a
simple maner, if you want to cover up for the possibility of syntax
errors during parsing and arbitrary number of command line arguments.

So, add cfg_setmulti (and cfg_opt_setmulti) to support this.