### PR TITLE
Fix issue #33: Reindent to Linux coding style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+Contributing to libConfuse
+==========================
+
+We welcome any and all help in the form of bug reports, fixes, patches
+for new features -- *preferably as [GitHub][github] pull requests* --
+submitting a pull request practically guarantees inclusion ...
+
+
+Coding Style
+------------
+
+First of all, lines are allowed to be longer than 72 characters these
+days.  In fact, there exist no enforced maximum, but keeping it around
+100/132 characters is OK.
+
+The coding style in libConfuse is Linux [KNF][], detailed [here][style].
+To aid developers contributing to the project, source files contain a
+trailer of `Local Variables:` used to instruct Emacs to use the correct
+indentation mode.  There is also a silly little script `indent.sh`,
+which is only supposed to serve as a help.
+
+> Always submit code that follows the style of surrounding code!
+
+
+Commit Messages
+---------------
+
+Commit messages exist to track *why* a change was made.  Try to be as
+clear and concise as possible in your commit messages.  Example from
+the [Pro Git][gitbook] online book:
+
+    Brief, but clear and concise summary of changes
+    
+    More detailed explanatory text, if necessary.  Wrap it to about 72
+    characters or so.  In some contexts, the first line is treated as
+    the subject of an email and the rest of the text as the body.  The
+    blank line separating the ummary from the body is critical (unless
+    you omit the body entirely); tools like rebase can get confused if
+    you run the two together.
+    
+    Further paragraphs come after blank lines.
+    
+     - Bullet points are okay, too
+    
+     - Typically a hyphen or asterisk is used for the bullet, preceded
+       by a single space, with blank lines in between, but conventions
+       vary here
+    
+    Signed-off-by: First Lastname <some.email@example.com>
+
+
+A good *counter* example [is this][rambling] ...
+
+
+Code of Conduct
+---------------
+
+It is expected of everyone engaging in the project to, in the words of
+Bill & Ted; be excellent to each other.
+
+
+[github]:   https://github.com/martinh/libconfuse/
+[KNF]:      https://en.wikipedia.org/wiki/Kernel_Normal_Form
+[style]:    https://www.kernel.org/doc/Documentation/CodingStyle
+[gitbook]:  https://git-scm.com/book/ch5-2.html
+[rambling]: http://stopwritingramblingcommitmessages.com/
+
+<!--
+  -- Local Variables:
+  -- mode: markdown
+  -- End:
+  -->

--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ Introduction
 ------------
 
 libConfuse is a configuration file parser library, licensed under the
-terms of the [ISC license](http://en.wikipedia.org/wiki/ISC_license),
-and written in C.  It supports sections and (lists of) values (strings,
-integers, floats, booleans or other sections), as well as some other
-features (such as single/double-quoted strings, environment variable
-expansion, functions and nested include statements).  It makes it very
-easy to add configuration file capability to a program using a simple
-API.
+terms of the [ISC license][1], and written in C.  It supports sections
+and (lists of) values (strings, integers, floats, booleans or other
+sections), as well as some other features (such as single/double-quoted
+strings, environment variable expansion, functions and nested include
+statements).  It makes it very easy to add configuration file capability
+to a program using a simple API.
 
 The goal of libConfuse is not to be _the_ configuration file parser
 library with a gazillion of features.  Instead, it aims to be easy to
@@ -32,7 +31,8 @@ use and quick to integrate with your code.
 libConfuse was called libcfg before, but was changed to not confuse with
 other similar libraries.
 
-Please report bugs to the GitHub [issue tracker](https://github.com/martinh/libconfuse/issues)
+Please report bugs to the GitHub [issue tracker][2].  If you want to
+contribute fixes or new features, see the file [CONTRIBUTING.md][3]
 
 
 Examples
@@ -127,6 +127,9 @@ News
 
 Copyright &copy; Martin Hedenfalk <[martin.nospam@bzero.se](mailto:martin@bzero.se)>
 
+[1]:                http://en.wikipedia.org/wiki/ISC_license
+[2]:                https://github.com/martinh/libconfuse/issues
+[3]:                https://github.com/martinh/libconfuse/blob/master/CONTRIBUTING.md
 [Travis]:           https://travis-ci.org/troglobit/libconfuse
 [Travis Status]:    https://travis-ci.org/troglobit/libconfuse.png?branch=master
 [Coverity Scan]:    https://scan.coverity.com/projects/6674

--- a/examples/cfgtest.c
+++ b/examples/cfgtest.c
@@ -3,43 +3,43 @@
 
 void print_func(cfg_opt_t *opt, unsigned int index, FILE *fp)
 {
-    fprintf(fp, "%s(foo)", opt->name);
+	fprintf(fp, "%s(foo)", opt->name);
 }
 
 void print_ask(cfg_opt_t *opt, unsigned int index, FILE *fp)
 {
-    int value = cfg_opt_getnint(opt, index);
-    switch(value) {
-        case 1:
-            fprintf(fp, "yes");
-            break;
-        case 2:
-            fprintf(fp, "no");
-            break;
-        case 3:
-        default:
-            fprintf(fp, "maybe");
-            break;
-    }
+	int value = cfg_opt_getnint(opt, index);
+
+	switch (value) {
+	case 1:
+		fprintf(fp, "yes");
+		break;
+	case 2:
+		fprintf(fp, "no");
+		break;
+	case 3:
+	default:
+		fprintf(fp, "maybe");
+		break;
+	}
 }
 
 /* function callback
  */
 int cb_func(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
 {
-    int i;
+	int i;
 
-    /* at least one parameter is required */
-    if(argc == 0) {
-        cfg_error(cfg, "Too few parameters for the '%s' function",
-                  opt->name);
-        return -1;
-    }
+	/* at least one parameter is required */
+	if (argc == 0) {
+		cfg_error(cfg, "Too few parameters for the '%s' function", opt->name);
+		return -1;
+	}
 
-    printf("cb_func() called with %d parameters:\n", argc);
-    for(i = 0; i < argc; i++)
-        printf("parameter %d: '%s'\n", i, argv[i]);
-    return 0;
+	printf("cb_func() called with %d parameters:\n", argc);
+	for (i = 0; i < argc; i++)
+		printf("parameter %d: '%s'\n", i, argv[i]);
+	return 0;
 }
 
 /* value parsing callback
@@ -49,174 +49,174 @@ int cb_func(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
  */
 int cb_verify_ask(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
-    if(strcmp(value, "yes") == 0)
-        *(long int *)result = 1;
-    else if(strcmp(value, "no") == 0)
-        *(long int *)result = 2;
-    else if(strcmp(value, "maybe") == 0)
-        *(long int *)result = 3;
-    else {
-        cfg_error(cfg, "Invalid value for option %s: %s", opt->name, value);
-        return -1;
-    }
-    return 0;
+	if (strcmp(value, "yes") == 0)
+		*(long int *)result = 1;
+	else if (strcmp(value, "no") == 0)
+		*(long int *)result = 2;
+	else if (strcmp(value, "maybe") == 0)
+		*(long int *)result = 3;
+	else {
+		cfg_error(cfg, "Invalid value for option %s: %s", opt->name, value);
+		return -1;
+	}
+	return 0;
 }
 
 int cb_validate_bookmark(cfg_t *cfg, cfg_opt_t *opt)
 {
-    /* only validate the last bookmark */
-    cfg_t *sec = cfg_opt_getnsec(opt, cfg_opt_size(opt) - 1);
-    if(!sec)
-    {
-        cfg_error(cfg, "section is NULL!?");
-        return -1;
-    }
-    if(cfg_getstr(sec, "machine") == 0)
-    {
-        cfg_error(cfg, "machine option must be set for bookmark '%s'",
-                  cfg_title(sec));
-        return -1;
-    }
-    return 0;
+	/* only validate the last bookmark */
+	cfg_t *sec = cfg_opt_getnsec(opt, cfg_opt_size(opt) - 1);
+
+	if (!sec) {
+		cfg_error(cfg, "section is NULL!?");
+		return -1;
+	}
+	if (cfg_getstr(sec, "machine") == 0) {
+		cfg_error(cfg, "machine option must be set for bookmark '%s'", cfg_title(sec));
+		return -1;
+	}
+	return 0;
 }
 
 int main(int argc, char **argv)
 {
-    unsigned int i;
-    cfg_t *cfg;
-    unsigned n;
-    int ret;
-    cfg_opt_t proxy_opts[] = {
-        CFG_INT("type", 0, CFGF_NONE),
-        CFG_STR("host", 0, CFGF_NONE),
-        CFG_STR_LIST("exclude", "{localhost, .localnet}", CFGF_NONE),
-        CFG_INT("port", 21, CFGF_NONE),
-        CFG_END()
-    };
-    cfg_opt_t bookmark_opts[] = {
-        CFG_STR("machine", 0, CFGF_NONE),
-        CFG_INT("port", 21, CFGF_NONE),
-        CFG_STR("login", 0, CFGF_NONE),
-        CFG_STR("password", 0, CFGF_NONE),
-        CFG_STR("directory", 0, CFGF_NONE),
-        CFG_BOOL("passive-mode", cfg_false, CFGF_NONE),
-        CFG_SEC("proxy", proxy_opts, CFGF_NONE),
-        CFG_END()
-    };
-    cfg_opt_t opts[] = {
-        CFG_INT("backlog", 42, CFGF_NONE),
-        CFG_STR("probe-device", "eth2", CFGF_NONE),
-        CFG_SEC("bookmark", bookmark_opts, CFGF_MULTI | CFGF_TITLE),
-        CFG_FLOAT_LIST("delays", "{3.567e2, 0.2, -47.11}", CFGF_NONE),
-        CFG_FUNC("func", &cb_func),
-        CFG_INT_CB("ask-quit", 3, CFGF_NONE, &cb_verify_ask),
-        CFG_INT_LIST_CB("ask-quit-array", "{maybe, yes, no}",
-                        CFGF_NONE, &cb_verify_ask),
-        CFG_FUNC("include", &cfg_include),
-        CFG_END()
-    };
+	unsigned int i;
+	cfg_t *cfg;
+	unsigned n;
+	int ret;
+
+	cfg_opt_t proxy_opts[] = {
+		CFG_INT("type", 0, CFGF_NONE),
+		CFG_STR("host", 0, CFGF_NONE),
+		CFG_STR_LIST("exclude", "{localhost, .localnet}", CFGF_NONE),
+		CFG_INT("port", 21, CFGF_NONE),
+		CFG_END()
+	};
+	cfg_opt_t bookmark_opts[] = {
+		CFG_STR("machine", 0, CFGF_NONE),
+		CFG_INT("port", 21, CFGF_NONE),
+		CFG_STR("login", 0, CFGF_NONE),
+		CFG_STR("password", 0, CFGF_NONE),
+		CFG_STR("directory", 0, CFGF_NONE),
+		CFG_BOOL("passive-mode", cfg_false, CFGF_NONE),
+		CFG_SEC("proxy", proxy_opts, CFGF_NONE),
+		CFG_END()
+	};
+	cfg_opt_t opts[] = {
+		CFG_INT("backlog", 42, CFGF_NONE),
+		CFG_STR("probe-device", "eth2", CFGF_NONE),
+		CFG_SEC("bookmark", bookmark_opts, CFGF_MULTI | CFGF_TITLE),
+		CFG_FLOAT_LIST("delays", "{3.567e2, 0.2, -47.11}", CFGF_NONE),
+		CFG_FUNC("func", &cb_func),
+		CFG_INT_CB("ask-quit", 3, CFGF_NONE, &cb_verify_ask),
+		CFG_INT_LIST_CB("ask-quit-array", "{maybe, yes, no}",
+				CFGF_NONE, &cb_verify_ask),
+		CFG_FUNC("include", &cfg_include),
+		CFG_END()
+	};
 
 #ifndef _WIN32
-    /* for some reason, MS Visual C++ chokes on this (?) */
-    printf("Using %s\n\n", confuse_copyright);
+	/* for some reason, MS Visual C++ chokes on this (?) */
+	printf("Using %s\n\n", confuse_copyright);
 #endif
 
-    cfg = cfg_init(opts, CFGF_NOCASE);
+	cfg = cfg_init(opts, CFGF_NOCASE);
 
-    /* set a validating callback function for bookmark sections */
-    cfg_set_validate_func(cfg, "bookmark", &cb_validate_bookmark);
+	/* set a validating callback function for bookmark sections */
+	cfg_set_validate_func(cfg, "bookmark", &cb_validate_bookmark);
 
-    ret = cfg_parse(cfg, argc > 1 ? argv[1] : "test.conf");
-    printf("ret == %d\n", ret);
-    if(ret == CFG_FILE_ERROR) {
-        perror("test.conf");
-        return 1;
-    } else if(ret == CFG_PARSE_ERROR) {
-        fprintf(stderr, "parse error\n");
-        return 2;
-    }
+	ret = cfg_parse(cfg, argc > 1 ? argv[1] : "test.conf");
+	printf("ret == %d\n", ret);
+	if (ret == CFG_FILE_ERROR) {
+		perror("test.conf");
+		return 1;
+	} else if (ret == CFG_PARSE_ERROR) {
+		fprintf(stderr, "parse error\n");
+		return 2;
+	}
 
-    printf("backlog == %ld\n", cfg_getint(cfg, "backlog"));
+	printf("backlog == %ld\n", cfg_getint(cfg, "backlog"));
 
-    printf("probe device is %s\n", cfg_getstr(cfg, "probe-device"));
-    cfg_setstr(cfg, "probe-device", "lo");
-    printf("probe device is %s\n", cfg_getstr(cfg, "probe-device"));
+	printf("probe device is %s\n", cfg_getstr(cfg, "probe-device"));
+	cfg_setstr(cfg, "probe-device", "lo");
+	printf("probe device is %s\n", cfg_getstr(cfg, "probe-device"));
 
-    n = cfg_size(cfg, "bookmark");
-    printf("%d configured bookmarks:\n", n);
-    for(i = 0; i < n; i++) {
-        cfg_t *pxy;
-        cfg_t *bm = cfg_getnsec(cfg, "bookmark", i);
-        printf("  bookmark #%u (%s):\n", i+1, cfg_title(bm));
-        printf("    machine = %s\n", cfg_getstr(bm, "machine"));
-        printf("    port = %d\n", (int)cfg_getint(bm, "port"));
-        printf("    login = %s\n", cfg_getstr(bm, "login"));
-        printf("    passive-mode = %s\n",
-               cfg_getbool(bm, "passive-mode") ? "true" : "false");
-        printf("    directory = %s\n", cfg_getstr(bm, "directory"));
-        printf("    password = %s\n", cfg_getstr(bm, "password"));
+	n = cfg_size(cfg, "bookmark");
+	printf("%d configured bookmarks:\n", n);
+	for (i = 0; i < n; i++) {
+		cfg_t *pxy;
+		cfg_t *bm = cfg_getnsec(cfg, "bookmark", i);
 
-        pxy = cfg_getsec(bm, "proxy");
-        if(pxy) {
-            int j, m;
-            if(cfg_getstr(pxy, "host") == 0) {
-                printf("      no proxy host is set, setting it to 'localhost'...\n");
-                /* For sections without CFGF_MULTI flag set, there is
-                 * also an extended syntax to get an option in a
-                 * subsection:
-                 */
-                cfg_setstr(bm, "proxy|host", "localhost");
-            }
-            printf("      proxy host is %s\n", cfg_getstr(pxy, "host"));
-            printf("      proxy type is %ld\n", cfg_getint(pxy, "type"));
-            printf("      proxy port is %ld\n", cfg_getint(pxy, "port"));
+		printf("  bookmark #%u (%s):\n", i + 1, cfg_title(bm));
+		printf("    machine = %s\n", cfg_getstr(bm, "machine"));
+		printf("    port = %d\n", (int)cfg_getint(bm, "port"));
+		printf("    login = %s\n", cfg_getstr(bm, "login"));
+		printf("    passive-mode = %s\n", cfg_getbool(bm, "passive-mode") ? "true" : "false");
+		printf("    directory = %s\n", cfg_getstr(bm, "directory"));
+		printf("    password = %s\n", cfg_getstr(bm, "password"));
 
-            m = cfg_size(pxy, "exclude");
-            printf("      got %d hosts to exclude from proxying:\n", m);
-            for(j = 0; j < m; j++) {
-                printf("        exclude %s\n", cfg_getnstr(pxy, "exclude", j));
-            }
-        } else
-            printf("    no proxy settings configured\n");
-    }
+		pxy = cfg_getsec(bm, "proxy");
+		if (pxy) {
+			int j, m;
 
-    printf("delays are (%d):\n", cfg_size(cfg, "delays"));
-    for(i = 0; i < cfg_size(cfg, "delays"); i++)
-        printf(" %G\n", cfg_getnfloat(cfg, "delays", i));
+			if (cfg_getstr(pxy, "host") == 0) {
+				printf("      no proxy host is set, setting it to 'localhost'...\n");
+				/* For sections without CFGF_MULTI flag set, there is
+				 * also an extended syntax to get an option in a
+				 * subsection:
+				 */
+				cfg_setstr(bm, "proxy|host", "localhost");
+			}
+			printf("      proxy host is %s\n", cfg_getstr(pxy, "host"));
+			printf("      proxy type is %ld\n", cfg_getint(pxy, "type"));
+			printf("      proxy port is %ld\n", cfg_getint(pxy, "port"));
 
-    printf("ask-quit == %ld\n", cfg_getint(cfg, "ask-quit"));
+			m = cfg_size(pxy, "exclude");
+			printf("      got %d hosts to exclude from proxying:\n", m);
+			for (j = 0; j < m; j++) {
+				printf("        exclude %s\n", cfg_getnstr(pxy, "exclude", j));
+			}
+		} else
+			printf("    no proxy settings configured\n");
+	}
 
-    /* Using cfg_setint(), the integer value for the option ask-quit
-     * is not verified by the value parsing callback.
-     *
-     *
-     cfg_setint(cfg, "ask-quit", 4);
-     printf("ask-quit == %ld\n", cfg_getint(cfg, "ask-quit"));
-    */
+	printf("delays are (%d):\n", cfg_size(cfg, "delays"));
+	for (i = 0; i < cfg_size(cfg, "delays"); i++)
+		printf(" %G\n", cfg_getnfloat(cfg, "delays", i));
 
-    /* The following commented line will generate a failed assertion
-     * and abort, since the option "foo" is not declared
-     *
-     *
-     printf("foo == %ld\n", cfg_getint(cfg, "foo"));
-    */
+	printf("ask-quit == %ld\n", cfg_getint(cfg, "ask-quit"));
 
-    cfg_addlist(cfg, "ask-quit-array", 2, 1, 2);
+	/* Using cfg_setint(), the integer value for the option ask-quit
+	 * is not verified by the value parsing callback.
+	 *
+	 *
+	 cfg_setint(cfg, "ask-quit", 4);
+	 printf("ask-quit == %ld\n", cfg_getint(cfg, "ask-quit"));
+	 */
 
-    for(i = 0; i < cfg_size(cfg, "ask-quit-array"); i++)
-        printf("ask-quit-array[%d] == %ld\n",
-               i, cfg_getnint(cfg, "ask-quit-array", i));
+	/* The following commented line will generate a failed assertion
+	 * and abort, since the option "foo" is not declared
+	 *
+	 *
+	 printf("foo == %ld\n", cfg_getint(cfg, "foo"));
+	 */
 
-    /* print the parsed values to another file */
-    {
-        FILE *fp = fopen("test.conf.out", "w");
-        cfg_set_print_func(cfg, "func", print_func);
-        cfg_set_print_func(cfg, "ask-quit", print_ask);
-        cfg_set_print_func(cfg, "ask-quit-array", print_ask);
-        cfg_print(cfg, fp);
-        fclose(fp);
-    }
+	cfg_addlist(cfg, "ask-quit-array", 2, 1, 2);
 
-    cfg_free(cfg);
-    return 0;
+	for (i = 0; i < cfg_size(cfg, "ask-quit-array"); i++)
+		printf("ask-quit-array[%d] == %ld\n", i, cfg_getnint(cfg, "ask-quit-array", i));
+
+	/* print the parsed values to another file */
+	{
+		FILE *fp = fopen("test.conf.out", "w");
+
+		cfg_set_print_func(cfg, "func", print_func);
+		cfg_set_print_func(cfg, "ask-quit", print_ask);
+		cfg_set_print_func(cfg, "ask-quit-array", print_ask);
+		cfg_print(cfg, fp);
+		fclose(fp);
+	}
+
+	cfg_free(cfg);
+	return 0;
 }

--- a/examples/cli.c
+++ b/examples/cli.c
@@ -23,8 +23,7 @@ static int cmdc;
 static char **cmdv;
 static int cmdv_max;
 
-static int
-reserve_cmdv(int cmdc)
+static int reserve_cmdv(int cmdc)
 {
 	int cmd_max = cmdv_max;
 	char **tmp;
@@ -45,8 +44,7 @@ reserve_cmdv(int cmdc)
 	return 0;
 }
 
-static int
-split_cmd(char *cmd)
+static int split_cmd(char *cmd)
 {
 	char *out = cmd;
 	int arg;
@@ -55,13 +53,15 @@ split_cmd(char *cmd)
 
 	for (;;) {
 		char ch;
+
 		arg = 0;
 		while (*cmd == ' ')
 			++cmd;
-next_char:
+ next_char:
 		ch = *cmd++;
 		if (ch == '"' || ch == '\'') {
 			char end = ch;
+
 			if (!arg) {
 				if (reserve_cmdv(cmdc + 1))
 					return -1;
@@ -91,8 +91,7 @@ next_char:
 	return cmdc;
 }
 
-static char *
-input_cmd(void)
+static char *input_cmd(void)
 {
 	int ch;
 	char *cmd = malloc(128);
@@ -114,6 +113,7 @@ input_cmd(void)
 		default:
 			if (pos == len) {
 				char *tmp = realloc(cmd, len * 2);
+
 				if (!tmp)
 					goto cleanup;
 				cmd = tmp;
@@ -124,30 +124,27 @@ input_cmd(void)
 				return cmd;
 		}
 	}
-cleanup:
+ cleanup:
 	free(cmd);
 	return NULL;
 }
 
-static const char *
-help(int argc, char *argv[])
+static const char *help(int argc, char *argv[])
 {
-	return
-"available commands:\n"
-"\n"
-"help\n"
-"set <option> <value> ...\n"
-"subset <section> <option> <value>\n"
-"create <section>\n"
-"destroy <section>\n"
-"dump\n"
-"quit\n"
-"\n"
-"<option> is one of 'bool', 'int' 'string' and 'float'.\n";
+	return  "Available commands:\n"
+		"\n"
+		"help\n"
+		"set <option> <value> ...\n"
+		"subset <section> <option> <value>\n"
+		"create <section>\n"
+		"destroy <section>\n"
+		"dump\n"
+		"quit\n"
+		"\n"
+		"<option> is one of 'bool', 'int' 'string' and 'float'.\n";
 }
 
-static const char *
-set(int argc, char *argv[])
+static const char *set(int argc, char *argv[])
 {
 	if (argc < 3)
 		return "Need more args\n";
@@ -161,8 +158,7 @@ set(int argc, char *argv[])
 	return "OK\n";
 }
 
-static const char *
-subset(int argc, char *argv[])
+static const char *subset(int argc, char *argv[])
 {
 	cfg_t *sub;
 
@@ -184,8 +180,7 @@ subset(int argc, char *argv[])
 	return "OK\n";
 }
 
-static const char *
-create(int argc, char *argv[])
+static const char *create(int argc, char *argv[])
 {
 	char *buf;
 
@@ -206,8 +201,7 @@ create(int argc, char *argv[])
 	return "OK\n";
 }
 
-static const char *
-destroy(int argc, char *argv[])
+static const char *destroy(int argc, char *argv[])
 {
 	if (argc < 2)
 		return "Need one arg\n";
@@ -219,22 +213,20 @@ destroy(int argc, char *argv[])
 	return "OK\n";
 }
 
-static const char *
-dump(int argc, char *argv[])
+static const char *dump(int argc, char *argv[])
 {
 	cfg_print(cfg, stdout);
 	return "";
 }
 
-static const char *
-quit(int argc, char *argv[])
+static const char *quit(int argc, char *argv[])
 {
 	return NULL;
 }
 
 struct cmd_handler {
 	const char *cmd;
-	const char *(*handler)(int argc, char *argv[]);
+	const char *(*handler) (int argc, char *argv[]);
 };
 
 static const struct cmd_handler cmds[] = {

--- a/examples/ftpconf.c
+++ b/examples/ftpconf.c
@@ -15,135 +15,122 @@
 /* called on alias() functions in the config file */
 int conf_alias(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
 {
-    if(argc < 2)
-    {
-        cfg_error(cfg, "function '%s' requires 2 arguments", cfg_opt_name(opt));
-        return -1;
-    }
-    printf("got alias '%s' = '%s'\n", argv[0], argv[1]);
-    return 0;
+	if (argc < 2) {
+		cfg_error(cfg, "function '%s' requires 2 arguments", cfg_opt_name(opt));
+		return -1;
+	}
+	printf("got alias '%s' = '%s'\n", argv[0], argv[1]);
+	return 0;
 }
 
 /* parse values for the auto-create-bookmark option */
 int conf_parse_acb(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
-    if(strcmp(value, "yes") == 0)
-        *(int *)result = ACB_YES;
-    else if(strcmp(value, "no") == 0)
-        *(int *)result = ACB_NO;
-    else if(strcmp(value, "ask") == 0)
-        *(int *)result = ACB_ASK;
-    else
-    {
-        cfg_error(cfg, "invalid value for option '%s': %s",
-	    cfg_opt_name(opt), value);
-        return -1;
-    }
-    return 0;
+	if (strcmp(value, "yes") == 0)
+		*(int *)result = ACB_YES;
+	else if (strcmp(value, "no") == 0)
+		*(int *)result = ACB_NO;
+	else if (strcmp(value, "ask") == 0)
+		*(int *)result = ACB_ASK;
+	else {
+		cfg_error(cfg, "invalid value for option '%s': %s", cfg_opt_name(opt), value);
+		return -1;
+	}
+	return 0;
 }
 
 /* validates a port option (must be positive) */
 int conf_validate_port(cfg_t *cfg, cfg_opt_t *opt)
 {
-    int value = cfg_opt_getnint(opt, 0);
-    if(value <= 0)
-    {
-        cfg_error(cfg, "invalid port %d in section '%s'", value, cfg_name(cfg));
-        return -1;
-    }
-    return 0;
+	int value = cfg_opt_getnint(opt, 0);
+
+	if (value <= 0) {
+		cfg_error(cfg, "invalid port %d in section '%s'", value, cfg_name(cfg));
+		return -1;
+	}
+	return 0;
 }
 
 /* validates a bookmark section (host option required) */
 int conf_validate_bookmark(cfg_t *cfg, cfg_opt_t *opt)
 {
-    cfg_t *bookmark = cfg_opt_getnsec(opt, cfg_opt_size(opt) - 1);
-    if(cfg_size(bookmark, "host") == 0)
-    {
-        cfg_error(cfg, "missing required option 'host' in bookmark");
-        return -1;
-    }
-    return 0;
+	cfg_t *bookmark = cfg_opt_getnsec(opt, cfg_opt_size(opt) - 1);
+
+	if (cfg_size(bookmark, "host") == 0) {
+		cfg_error(cfg, "missing required option 'host' in bookmark");
+		return -1;
+	}
+	return 0;
 }
 
 cfg_t *parse_conf(const char *filename)
 {
-    static cfg_opt_t bookmark_opts[] = {
-        CFG_STR("host", 0, CFGF_NODEFAULT),
-        CFG_INT("port", 21, CFGF_NONE),
-        CFG_STR("login", "anonymous", CFGF_NONE),
-        CFG_STR("password", "anonymous@", CFGF_NONE),
-        CFG_STR("directory", 0, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t bookmark_opts[] = {
+		CFG_STR("host", 0, CFGF_NODEFAULT),
+		CFG_INT("port", 21, CFGF_NONE),
+		CFG_STR("login", "anonymous", CFGF_NONE),
+		CFG_STR("password", "anonymous@", CFGF_NONE),
+		CFG_STR("directory", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = {
-        CFG_SEC("bookmark", bookmark_opts, CFGF_MULTI | CFGF_TITLE),
-        CFG_BOOL("passive-mode", cfg_false, CFGF_NONE),
-        CFG_BOOL("remote-completion", cfg_true, CFGF_NONE),
-        CFG_FUNC("alias", conf_alias),
-        CFG_STR_LIST("xterm-terminals", "{xterm, rxvt}", CFGF_NONE),
-        CFG_INT_CB("auto-create-bookmark", ACB_YES, CFGF_NONE, conf_parse_acb),
-        CFG_FUNC("include-file", cfg_include),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_SEC("bookmark", bookmark_opts, CFGF_MULTI | CFGF_TITLE),
+		CFG_BOOL("passive-mode", cfg_false, CFGF_NONE),
+		CFG_BOOL("remote-completion", cfg_true, CFGF_NONE),
+		CFG_FUNC("alias", conf_alias),
+		CFG_STR_LIST("xterm-terminals", "{xterm, rxvt}", CFGF_NONE),
+		CFG_INT_CB("auto-create-bookmark", ACB_YES, CFGF_NONE, conf_parse_acb),
+		CFG_FUNC("include-file", cfg_include),
+		CFG_END()
+	};
 
-    cfg_t *cfg = cfg_init(opts, CFGF_NONE);
-    cfg_set_validate_func(cfg, "bookmark|port", conf_validate_port);
-    cfg_set_validate_func(cfg, "bookmark", conf_validate_bookmark);
+	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
 
-    switch(cfg_parse(cfg, filename))
-    {
-        case CFG_FILE_ERROR:
-            printf("warning: configuration file '%s' could not be read: %s\n",
-                    filename, strerror(errno));
-            printf("continuing with default values...\n\n");
-        case CFG_SUCCESS:
-            break;
-        case CFG_PARSE_ERROR:
-            return 0;
-    }
+	cfg_set_validate_func(cfg, "bookmark|port", conf_validate_port);
+	cfg_set_validate_func(cfg, "bookmark", conf_validate_bookmark);
 
-    return cfg;
+	switch (cfg_parse(cfg, filename)) {
+	case CFG_FILE_ERROR:
+		printf("warning: configuration file '%s' could not be read: %s\n", filename, strerror(errno));
+		printf("continuing with default values...\n\n");
+	case CFG_SUCCESS:
+		break;
+	case CFG_PARSE_ERROR:
+		return 0;
+	}
+
+	return cfg;
 }
 
 int main(int argc, char **argv)
 {
-    cfg_t *cfg = parse_conf(argc > 1 ? argv[1] : "ftp.conf");
+	cfg_t *cfg = parse_conf(argc > 1 ? argv[1] : "ftp.conf");
 
-    /* print the parsed configuration options */
-    if(cfg)
-    {
-        unsigned int i;
+	/* print the parsed configuration options */
+	if (cfg) {
+		unsigned int i;
 
-        printf("passive-mode = %s\n",
-	    cfg_getbool(cfg, "passive-mode") ? "true" : "false");
-        printf("remote-completion = %s\n",
-	    cfg_getbool(cfg, "remote-completion") ? "true" : "false");
+		printf("passive-mode = %s\n", cfg_getbool(cfg, "passive-mode") ? "true" : "false");
+		printf("remote-completion = %s\n", cfg_getbool(cfg, "remote-completion") ? "true" : "false");
 
-        printf("number of bookmarks: %d\n", cfg_size(cfg, "bookmark"));
-        for(i = 0; i < cfg_size(cfg, "bookmark"); i++)
-        {
-            cfg_t *bookmark = cfg_getnsec(cfg, "bookmark", i);
-            printf("  bookmark #%d: %s:%s@%s:%ld%s\n", i+1,
-                    cfg_getstr(bookmark, "login"),
-                    cfg_getstr(bookmark, "password"),
-                    cfg_getstr(bookmark, "host"),
-                    cfg_getint(bookmark, "port"),
-                    cfg_getstr(bookmark, "directory"));
-        }
+		printf("number of bookmarks: %d\n", cfg_size(cfg, "bookmark"));
+		for (i = 0; i < cfg_size(cfg, "bookmark"); i++) {
+			cfg_t *bookmark = cfg_getnsec(cfg, "bookmark", i);
 
-        for(i = 0; i < cfg_size(cfg, "xterm-terminals"); i++)
-	{
-            printf("xterm-terminal #%d: %s\n",
-		i+1, cfg_getnstr(cfg, "xterm-terminals", i));
+			printf("  bookmark #%d: %s:%s@%s:%ld%s\n", i + 1,
+			       cfg_getstr(bookmark, "login"),
+			       cfg_getstr(bookmark, "password"),
+			       cfg_getstr(bookmark, "host"), cfg_getint(bookmark, "port"), cfg_getstr(bookmark, "directory"));
+		}
+
+		for (i = 0; i < cfg_size(cfg, "xterm-terminals"); i++) {
+			printf("xterm-terminal #%d: %s\n", i + 1, cfg_getnstr(cfg, "xterm-terminals", i));
+		}
+
+		printf("auto-create-bookmark = %ld\n", cfg_getint(cfg, "auto-create-bookmark"));
+		cfg_free(cfg);
 	}
 
-        printf("auto-create-bookmark = %ld\n",
-	    cfg_getint(cfg, "auto-create-bookmark"));
-        cfg_free(cfg);
-    }
-
-    return 0;
+	return 0;
 }
-

--- a/examples/reread.c
+++ b/examples/reread.c
@@ -8,66 +8,62 @@ const char *config_filename = "./reread.conf";
 
 void read_config(void)
 {
-    static cfg_opt_t arg_opts[] = {
-        CFG_STR("value", "default", CFGF_NONE),
-        CFG_END()
-    };
-    cfg_opt_t opts[] = {
-        CFG_INT("delay", 3, CFGF_NONE),
-        CFG_STR("message", "This is a message", CFGF_NONE),
-        CFG_SEC("argument", arg_opts, CFGF_MULTI | CFGF_TITLE),
-        CFG_END()
-    };
+	static cfg_opt_t arg_opts[] = {
+		CFG_STR("value", "default", CFGF_NONE),
+		CFG_END()
+	};
+	cfg_opt_t opts[] = {
+		CFG_INT("delay", 3, CFGF_NONE),
+		CFG_STR("message", "This is a message", CFGF_NONE),
+		CFG_SEC("argument", arg_opts, CFGF_MULTI | CFGF_TITLE),
+		CFG_END()
+	};
 
-    char *buf = "" \
-        " delay = 3\n" \
-        "# message = \"asdfasfasfd tersf\"\n" \
-        " argument one { value = 1 }\n" \
-        " argument two { value=foo}\n";
+	char *buf = ""
+	    " delay = 3\n" "# message = \"asdfasfasfd tersf\"\n" " argument one { value = 1 }\n" " argument two { value=foo}\n";
 
-    cfg_free(cfg);
+	cfg_free(cfg);
 
-    cfg = cfg_init(opts, 0);
-    cfg_parse_buf(cfg, buf);
-    cfg_parse(cfg, config_filename);
+	cfg = cfg_init(opts, 0);
+	cfg_parse_buf(cfg, buf);
+	cfg_parse(cfg, config_filename);
 }
 
 void sighandler(int sig)
 {
-    read_config();
-    signal(SIGHUP, sighandler);
+	read_config();
+	signal(SIGHUP, sighandler);
 }
 
 static int loop = 1;
 
 void usr1handler(int sig)
 {
-    loop = 0;
+	loop = 0;
 }
 
 int main(void)
 {
-    unsigned int i;
+	unsigned int i;
 
-    read_config();
-    signal(SIGHUP, sighandler);
-    signal(SIGUSR1, usr1handler);
+	read_config();
+	signal(SIGHUP, sighandler);
+	signal(SIGUSR1, usr1handler);
 
-    while(loop)
-    {
-        printf("Message: %s", cfg_getstr(cfg, "message"));
-        for(i = 0; i < cfg_size(cfg, "argument"); i++)
-        {
-            cfg_t *arg = cfg_getnsec(cfg, "argument", i);
-            printf(", %s", cfg_getstr(arg, "value"));
-        }
-        printf("\n");
+	while (loop) {
+		printf("Message: %s", cfg_getstr(cfg, "message"));
+		for (i = 0; i < cfg_size(cfg, "argument"); i++) {
+			cfg_t *arg = cfg_getnsec(cfg, "argument", i);
 
-        sleep(cfg_getint(cfg, "delay"));
-    }
+			printf(", %s", cfg_getstr(arg, "value"));
+		}
+		printf("\n");
 
-    cfg_free(cfg);
-    cfg = 0;
+		sleep(cfg_getint(cfg, "delay"));
+	}
 
-    return 0;
+	cfg_free(cfg);
+	cfg = 0;
+
+	return 0;
 }

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -5,65 +5,66 @@
 
 int main(void)
 {
-    static cfg_bool_t verbose = cfg_false;
-    static char *server = NULL;
-    static double delay = 1.356e-32;
-    static char *username = NULL;
+	static cfg_bool_t verbose = cfg_false;
+	static char *server = NULL;
+	static double delay = 1.356e-32;
+	static char *username = NULL;
 
-    /* Although the macro used to specify an integer option is called
-     * CFG_SIMPLE_INT(), it actually expects a long int. On a 64 bit system
-     * where ints are 32 bit and longs 64 bit (such as the x86-64 or amd64
-     * architectures), you will get weird effects if you use an int here.
-     *
-     * If you use the regular (non-"simple") options, ie CFG_INT() and use
-     * cfg_getint(), this is not a problem as the data types are implicitly
-     * cast.
-     */
-    static long int debug = 1;
+	/* Although the macro used to specify an integer option is called
+	 * CFG_SIMPLE_INT(), it actually expects a long int. On a 64 bit system
+	 * where ints are 32 bit and longs 64 bit (such as the x86-64 or amd64
+	 * architectures), you will get weird effects if you use an int here.
+	 *
+	 * If you use the regular (non-"simple") options, ie CFG_INT() and use
+	 * cfg_getint(), this is not a problem as the data types are implicitly
+	 * cast.
+	 */
+	static long int debug = 1;
 
-    cfg_opt_t opts[] = {
-        CFG_SIMPLE_BOOL("verbose", &verbose),
-        CFG_SIMPLE_STR("server", &server),
-        CFG_SIMPLE_STR("user", &username),
-        CFG_SIMPLE_INT("debug", &debug),
-        CFG_SIMPLE_FLOAT("delay", &delay),
-        CFG_END()
-    };
-    cfg_t *cfg;
+	cfg_opt_t opts[] = {
+		CFG_SIMPLE_BOOL("verbose", &verbose),
+		CFG_SIMPLE_STR("server", &server),
+		CFG_SIMPLE_STR("user", &username),
+		CFG_SIMPLE_INT("debug", &debug),
+		CFG_SIMPLE_FLOAT("delay", &delay),
+		CFG_END()
+	};
+	cfg_t *cfg;
 
-    /* set default value for the server option */
-    server = strdup("gazonk");
+	/* set default value for the server option */
+	server = strdup("gazonk");
 
-    cfg = cfg_init(opts, 0);
-    cfg_parse(cfg, "simple.conf");
+	cfg = cfg_init(opts, 0);
+	cfg_parse(cfg, "simple.conf");
 
-    printf("verbose: %s\n", verbose ? "true" : "false");
-    printf("server: %s\n", server);
-    printf("username: %s\n", username);
-    printf("debug: %ld\n", debug);
-    printf("delay: %G\n", delay);
+	printf("verbose: %s\n", verbose ? "true" : "false");
+	printf("server: %s\n", server);
+	printf("username: %s\n", username);
+	printf("debug: %ld\n", debug);
+	printf("delay: %G\n", delay);
 
-    printf("setting username to 'foo'\n");
-    /* using cfg_setstr here is not necessary at all, the equivalent
-     * code is:
-     *   free(username);
-     *   username = strdup("foo");
-     */
-    cfg_setstr(cfg, "user", "foo");
-    printf("username: %s\n", username);
+	printf("setting username to 'foo'\n");
+	/* using cfg_setstr here is not necessary at all, the equivalent
+	 * code is:
+	 *   free(username);
+	 *   username = strdup("foo");
+	 */
+	cfg_setstr(cfg, "user", "foo");
+	printf("username: %s\n", username);
 
-    /* print the parsed values to another file */
-    {
-        FILE *fp = fopen("simple.conf.out", "w");
-        cfg_print(cfg, fp);
-        fclose(fp);
-    }
+	/* print the parsed values to another file */
+	{
+		FILE *fp = fopen("simple.conf.out", "w");
 
-    cfg_free(cfg);
+		cfg_print(cfg, fp);
+		fclose(fp);
+	}
 
-    /* You are responsible for freeing string values. */
-    free(server);
-    free(username);
+	cfg_free(cfg);
 
-    return 0;
+	/* You are responsible for freeing string values. */
+	free(server);
+	free(username);
+
+	return 0;
 }

--- a/indent.sh
+++ b/indent.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# This script helps with the libConfuse coding style, but
+# remember: "indent" is not a fix for bad programming.
+# 
+# Rules:
+#   - Linux style, https://www.kernel.org/doc/Documentation/CodingStyle
+#   - Don't touch comment content/formatting, only placement.
+#   - ignore any ~/.indent.pro
+#
+# With the -T <type> we can inform indent about non-ansi types that
+# we've added, so indent doesn't insert spaces in odd places.
+# 
+indent --linux-style							\
+       --ignore-profile							\
+       --preserve-mtime							\
+       --break-after-boolean-operator					\
+       --blank-lines-after-procedures					\
+       --blank-lines-after-declarations					\
+       --dont-break-function-decl-args					\
+       --dont-break-procedure-type					\
+       --leave-preprocessor-space					\
+       --line-length132							\
+       --honour-newlines						\
+       --space-after-if							\
+       --space-after-for						\
+       --space-after-while						\
+       --leave-optional-blank-lines					\
+       --dont-format-comments						\
+       --no-blank-lines-after-commas					\
+       --no-space-after-parentheses					\
+       --no-space-after-casts						\
+       -T size_t -T FILE -T uint32_t -T uint16_t -T uint8_t		\
+       -T cfg_type_t -T cfg_value_t -T cfg_simple_t -T cfg_opt_t	\
+       -T cfg_t -T cfg_defvalue_t -T cfg_flag_t -T cfg_searchpath_t	\
+       -T cfg_bool_t -T cfg_func_t -T cfg_free_func_t -T cfg_errfunc_t	\
+       -T cfg_print_func_t -T cfg_callback_t -T cfg_validate_callback_t	\
+$*

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -64,11 +64,10 @@ extern char *cfg_qstring;
 char *cfg_yylval = 0;
 
 const char confuse_version[] = PACKAGE_VERSION;
-const char confuse_copyright[] = PACKAGE_STRING" by Martin Hedenfalk <martin@bzero.se>";
+const char confuse_copyright[] = PACKAGE_STRING " by Martin Hedenfalk <martin@bzero.se>";
 const char confuse_author[] = "Martin Hedenfalk <martin@bzero.se>";
 
-static int cfg_parse_internal(cfg_t *cfg, int level,
-                              int force_state, cfg_opt_t *force_opt);
+static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t *force_opt);
 
 #define STATE_CONTINUE 0
 #define STATE_EOF -1
@@ -113,9 +112,11 @@ static char *strdup(const char *s)
 
 	siz = strlen(str) + 1;
 	if ((copy = malloc(siz)) == NULL)
-		return(NULL);
+		return NULL;
+
 	memcpy(copy, str, siz);
-	return(copy);
+
+	return copy;
 }
 # endif
 #endif
@@ -123,1778 +124,1600 @@ static char *strdup(const char *s)
 #ifndef HAVE_STRNDUP
 static char *strndup(const char *s, size_t n)
 {
-    char *r;
+	char *r;
 
-    if(s == 0)
-        return 0;
+	if (s == 0)
+		return 0;
 
-    r = malloc(n + 1);
-    assert(r);
-    strncpy(r, s, n);
-    r[n] = 0;
-    return r;
+	r = malloc(n + 1);
+	assert(r);
+	strncpy(r, s, n);
+	r[n] = 0;
+	return r;
 }
 #endif
 
 #ifndef HAVE_STRCASECMP
 int strcasecmp(const char *s1, const char *s2)
 {
-    assert(s1);
-    assert(s2);
+	assert(s1);
+	assert(s2);
 
-    while(*s1)
-    {
-	int c1 = tolower(*(const unsigned char *)s1);
-	int c2 = tolower(*(const unsigned char *)s2);
-	if(c1 < c2)
-	    return -1;
-	if(c1 > c2)
-	    return +1;
+	while (*s1) {
+		int c1 = tolower(*(const unsigned char *)s1);
+		int c2 = tolower(*(const unsigned char *)s2);
 
-	++s1;
-	++s2;
-    }
+		if (c1 < c2)
+			return -1;
+		if (c1 > c2)
+			return +1;
 
-    if(*s2 != 0)
-	return -1;
+		++s1;
+		++s2;
+	}
 
-    return 0;
+	if (*s2 != 0)
+		return -1;
+
+	return 0;
 }
 #endif
 
 DLLIMPORT cfg_opt_t *cfg_getopt(cfg_t *cfg, const char *name)
 {
-    unsigned int i;
-    cfg_t *sec = cfg;
+	unsigned int i;
+	cfg_t *sec = cfg;
 
-    assert(cfg && cfg->name && name);
+	assert(cfg && cfg->name && name);
 
-    while(name && *name)
-    {
-        char *secname;
-        size_t len = strcspn(name, "|");
-        if(name[len] == 0 /*len == strlen(name)*/)
-            /* no more subsections */
-            break;
-        if(len)
-        {
-            secname = strndup(name, len);
-            sec = cfg_getsec(sec, secname);
-            if(sec == 0)
-                cfg_error(cfg, _("no such option '%s'"), secname);
-            free(secname);
-            if(sec == 0)
-                return 0;
-        }
-        name += len;
-        name += strspn(name, "|");
-    }
+	while (name && *name) {
+		char *secname;
+		size_t len = strcspn(name, "|");
 
-    for(i = 0; sec->opts[i].name; i++)
-    {
-        if(is_set(CFGF_NOCASE, sec->flags))
-        {
-            if(strcasecmp(sec->opts[i].name, name) == 0)
-                return &sec->opts[i];
-        }
-        else
-        {
-            if(strcmp(sec->opts[i].name, name) == 0)
-                return &sec->opts[i];
-        }
-    }
-    cfg_error(cfg, _("no such option '%s'"), name);
-    return 0;
+		if (name[len] == 0 /*len == strlen(name) */ )
+			/* no more subsections */
+			break;
+		if (len) {
+			secname = strndup(name, len);
+			sec = cfg_getsec(sec, secname);
+			if (sec == 0)
+				cfg_error(cfg, _("no such option '%s'"), secname);
+			free(secname);
+			if (sec == 0)
+				return 0;
+		}
+		name += len;
+		name += strspn(name, "|");
+	}
+
+	for (i = 0; sec->opts[i].name; i++) {
+		if (is_set(CFGF_NOCASE, sec->flags)) {
+			if (strcasecmp(sec->opts[i].name, name) == 0)
+				return &sec->opts[i];
+		} else {
+			if (strcmp(sec->opts[i].name, name) == 0)
+				return &sec->opts[i];
+		}
+	}
+	cfg_error(cfg, _("no such option '%s'"), name);
+	return 0;
 }
 
 DLLIMPORT const char *cfg_title(cfg_t *cfg)
 {
-    if(cfg)
-        return cfg->title;
-    return 0;
+	if (cfg)
+		return cfg->title;
+	return 0;
 }
 
 DLLIMPORT const char *cfg_name(cfg_t *cfg)
 {
-    if(cfg)
-        return cfg->name;
-    return 0;
+	if (cfg)
+		return cfg->name;
+	return 0;
 }
 
 DLLIMPORT const char *cfg_opt_name(cfg_opt_t *opt)
 {
-    if(opt)
-        return opt->name;
-    return 0;
+	if (opt)
+		return opt->name;
+	return 0;
 }
 
 DLLIMPORT unsigned int cfg_opt_size(cfg_opt_t *opt)
 {
-    if(opt)
-        return opt->nvalues;
-    return 0;
+	if (opt)
+		return opt->nvalues;
+	return 0;
 }
 
 DLLIMPORT unsigned int cfg_size(cfg_t *cfg, const char *name)
 {
-    return cfg_opt_size(cfg_getopt(cfg, name));
+	return cfg_opt_size(cfg_getopt(cfg, name));
 }
 
 DLLIMPORT signed long cfg_opt_getnint(cfg_opt_t *opt, unsigned int index)
 {
-    assert(opt && opt->type == CFGT_INT);
-    if(opt->values && index < opt->nvalues)
-        return opt->values[index]->number;
-    else if(opt->simple_value.number)
-        return *opt->simple_value.number;
-    else
-        return 0;
+	assert(opt && opt->type == CFGT_INT);
+	if (opt->values && index < opt->nvalues)
+		return opt->values[index]->number;
+	else if (opt->simple_value.number)
+		return *opt->simple_value.number;
+	else
+		return 0;
 }
 
-DLLIMPORT signed long cfg_getnint(cfg_t *cfg, const char *name,
-                                  unsigned int index)
+DLLIMPORT signed long cfg_getnint(cfg_t *cfg, const char *name, unsigned int index)
 {
-    return cfg_opt_getnint(cfg_getopt(cfg, name), index);
+	return cfg_opt_getnint(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT signed long cfg_getint(cfg_t *cfg, const char *name)
 {
-    return cfg_getnint(cfg, name, 0);
+	return cfg_getnint(cfg, name, 0);
 }
 
 DLLIMPORT double cfg_opt_getnfloat(cfg_opt_t *opt, unsigned int index)
 {
-    assert(opt && opt->type == CFGT_FLOAT);
-    if(opt->values && index < opt->nvalues)
-        return opt->values[index]->fpnumber;
-    else if(opt->simple_value.fpnumber)
-        return *opt->simple_value.fpnumber;
-    else
-        return 0;
+	assert(opt && opt->type == CFGT_FLOAT);
+	if (opt->values && index < opt->nvalues)
+		return opt->values[index]->fpnumber;
+	else if (opt->simple_value.fpnumber)
+		return *opt->simple_value.fpnumber;
+	else
+		return 0;
 }
 
-DLLIMPORT double cfg_getnfloat(cfg_t *cfg, const char *name,
-                               unsigned int index)
+DLLIMPORT double cfg_getnfloat(cfg_t *cfg, const char *name, unsigned int index)
 {
-    return cfg_opt_getnfloat(cfg_getopt(cfg, name), index);
+	return cfg_opt_getnfloat(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT double cfg_getfloat(cfg_t *cfg, const char *name)
 {
-    return cfg_getnfloat(cfg, name, 0);
+	return cfg_getnfloat(cfg, name, 0);
 }
 
 DLLIMPORT cfg_bool_t cfg_opt_getnbool(cfg_opt_t *opt, unsigned int index)
 {
-    assert(opt && opt->type == CFGT_BOOL);
-    if(opt->values && index < opt->nvalues)
-        return opt->values[index]->boolean;
-    else if(opt->simple_value.boolean)
-        return *opt->simple_value.boolean;
-    else
-        return cfg_false;
+	assert(opt && opt->type == CFGT_BOOL);
+	if (opt->values && index < opt->nvalues)
+		return opt->values[index]->boolean;
+	else if (opt->simple_value.boolean)
+		return *opt->simple_value.boolean;
+	else
+		return cfg_false;
 }
 
-DLLIMPORT cfg_bool_t cfg_getnbool(cfg_t *cfg, const char *name,
-                                  unsigned int index)
+DLLIMPORT cfg_bool_t cfg_getnbool(cfg_t *cfg, const char *name, unsigned int index)
 {
-    return cfg_opt_getnbool(cfg_getopt(cfg, name), index);
+	return cfg_opt_getnbool(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT cfg_bool_t cfg_getbool(cfg_t *cfg, const char *name)
 {
-    return cfg_getnbool(cfg, name, 0);
+	return cfg_getnbool(cfg, name, 0);
 }
 
 DLLIMPORT char *cfg_opt_getnstr(cfg_opt_t *opt, unsigned int index)
 {
-    assert(opt && opt->type == CFGT_STR);
-    if(opt->values && index < opt->nvalues)
-        return opt->values[index]->string;
-    else if(opt->simple_value.string)
-        return *opt->simple_value.string;
-    else
-        return 0;
+	assert(opt && opt->type == CFGT_STR);
+	if (opt->values && index < opt->nvalues)
+		return opt->values[index]->string;
+	else if (opt->simple_value.string)
+		return *opt->simple_value.string;
+	else
+		return 0;
 }
 
 DLLIMPORT char *cfg_getnstr(cfg_t *cfg, const char *name, unsigned int index)
 {
-    return cfg_opt_getnstr(cfg_getopt(cfg, name), index);
+	return cfg_opt_getnstr(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT char *cfg_getstr(cfg_t *cfg, const char *name)
 {
-    return cfg_getnstr(cfg, name, 0);
+	return cfg_getnstr(cfg, name, 0);
 }
 
 DLLIMPORT void *cfg_opt_getnptr(cfg_opt_t *opt, unsigned int index)
 {
-    assert(opt && opt->type == CFGT_PTR);
-    if(opt->values && index < opt->nvalues)
-        return opt->values[index]->ptr;
-    else if(opt->simple_value.ptr)
-        return *opt->simple_value.ptr;
-    else
-        return 0;
+	assert(opt && opt->type == CFGT_PTR);
+	if (opt->values && index < opt->nvalues)
+		return opt->values[index]->ptr;
+	else if (opt->simple_value.ptr)
+		return *opt->simple_value.ptr;
+	else
+		return 0;
 }
 
 DLLIMPORT void *cfg_getnptr(cfg_t *cfg, const char *name, unsigned int index)
 {
-    return cfg_opt_getnptr(cfg_getopt(cfg, name), index);
+	return cfg_opt_getnptr(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT void *cfg_getptr(cfg_t *cfg, const char *name)
 {
-    return cfg_getnptr(cfg, name, 0);
+	return cfg_getnptr(cfg, name, 0);
 }
 
 DLLIMPORT cfg_t *cfg_opt_getnsec(cfg_opt_t *opt, unsigned int index)
 {
-    assert(opt && opt->type == CFGT_SEC);
-    if(opt->values && index < opt->nvalues)
-        return opt->values[index]->section;
-    return 0;
+	assert(opt && opt->type == CFGT_SEC);
+	if (opt->values && index < opt->nvalues)
+		return opt->values[index]->section;
+	return 0;
 }
 
 DLLIMPORT cfg_t *cfg_getnsec(cfg_t *cfg, const char *name, unsigned int index)
 {
-    return cfg_opt_getnsec(cfg_getopt(cfg, name), index);
+	return cfg_opt_getnsec(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT cfg_t *cfg_opt_gettsec(cfg_opt_t *opt, const char *title)
 {
-    unsigned int i, n;
+	unsigned int i, n;
 
-    assert(opt && title);
-    if(!is_set(CFGF_TITLE, opt->flags))
-        return 0;
-    n = cfg_opt_size(opt);
-    for(i = 0; i < n; i++)
-    {
-        cfg_t *sec = cfg_opt_getnsec(opt, i);
-        assert(sec && sec->title);
-        if(is_set(CFGF_NOCASE, opt->flags))
-        {
-            if(strcasecmp(title, sec->title) == 0)
-                return sec;
-        }
-        else
-        {
-            if(strcmp(title, sec->title) == 0)
-                return sec;
-        }
-    }
-    return 0;
+	assert(opt && title);
+	if (!is_set(CFGF_TITLE, opt->flags))
+		return 0;
+	n = cfg_opt_size(opt);
+	for (i = 0; i < n; i++) {
+		cfg_t *sec = cfg_opt_getnsec(opt, i);
+
+		assert(sec && sec->title);
+		if (is_set(CFGF_NOCASE, opt->flags)) {
+			if (strcasecmp(title, sec->title) == 0)
+				return sec;
+		} else {
+			if (strcmp(title, sec->title) == 0)
+				return sec;
+		}
+	}
+	return 0;
 }
 
 DLLIMPORT cfg_t *cfg_gettsec(cfg_t *cfg, const char *name, const char *title)
 {
-    return cfg_opt_gettsec(cfg_getopt(cfg, name), title);
+	return cfg_opt_gettsec(cfg_getopt(cfg, name), title);
 }
 
 DLLIMPORT cfg_t *cfg_getsec(cfg_t *cfg, const char *name)
 {
-    return cfg_getnsec(cfg, name, 0);
+	return cfg_getnsec(cfg, name, 0);
 }
 
 static cfg_value_t *cfg_addval(cfg_opt_t *opt)
 {
-    opt->values = realloc(opt->values,
-                                  (opt->nvalues+1) * sizeof(cfg_value_t *));
-    assert(opt->values);
-    opt->values[opt->nvalues] = malloc(sizeof(cfg_value_t));
-    memset(opt->values[opt->nvalues], 0, sizeof(cfg_value_t));
-    return opt->values[opt->nvalues++];
+	opt->values = realloc(opt->values, (opt->nvalues + 1) * sizeof(cfg_value_t *));
+	assert(opt->values);
+	opt->values[opt->nvalues] = malloc(sizeof(cfg_value_t));
+	memset(opt->values[opt->nvalues], 0, sizeof(cfg_value_t));
+	return opt->values[opt->nvalues++];
 }
 
 DLLIMPORT int cfg_numopts(cfg_opt_t *opts)
 {
-    int n;
+	int n;
 
-    for(n = 0; opts[n].name; n++)
-        /* do nothing */ ;
-    return n;
+	for (n = 0; opts[n].name; n++)
+		/* do nothing */ ;
+	return n;
 }
 
 static cfg_opt_t *cfg_dupopt_array(cfg_opt_t *opts)
 {
-    int i;
-    cfg_opt_t *dupopts;
-    int n = cfg_numopts(opts);
+	int i;
+	cfg_opt_t *dupopts;
+	int n = cfg_numopts(opts);
 
-    dupopts = calloc(n+1, sizeof(cfg_opt_t));
-    memcpy(dupopts, opts, n * sizeof(cfg_opt_t));
+	dupopts = calloc(n + 1, sizeof(cfg_opt_t));
+	memcpy(dupopts, opts, n * sizeof(cfg_opt_t));
 
-    for(i = 0; i < n; i++)
-    {
-        dupopts[i].name = strdup(opts[i].name);
-        if(opts[i].type == CFGT_SEC && opts[i].subopts)
-            dupopts[i].subopts = cfg_dupopt_array(opts[i].subopts);
+	for (i = 0; i < n; i++) {
+		dupopts[i].name = strdup(opts[i].name);
+		if (opts[i].type == CFGT_SEC && opts[i].subopts)
+			dupopts[i].subopts = cfg_dupopt_array(opts[i].subopts);
 
-        if(is_set(CFGF_LIST, opts[i].flags) || opts[i].type == CFGT_FUNC)
-            dupopts[i].def.parsed = opts[i].def.parsed ? strdup(opts[i].def.parsed) : 0;
-        else if(opts[i].type == CFGT_STR)
-            dupopts[i].def.string = opts[i].def.string ? strdup(opts[i].def.string) : 0;
-    }
+		if (is_set(CFGF_LIST, opts[i].flags) || opts[i].type == CFGT_FUNC)
+			dupopts[i].def.parsed = opts[i].def.parsed ? strdup(opts[i].def.parsed) : 0;
+		else if (opts[i].type == CFGT_STR)
+			dupopts[i].def.string = opts[i].def.string ? strdup(opts[i].def.string) : 0;
+	}
 
-    return dupopts;
+	return dupopts;
 }
 
 DLLIMPORT int cfg_parse_boolean(const char *s)
 {
-    if(strcasecmp(s, "true") == 0
-       || strcasecmp(s, "on") == 0
-       || strcasecmp(s, "yes") == 0)
-        return 1;
-    else if(strcasecmp(s, "false") == 0
-            || strcasecmp(s, "off") == 0
-            || strcasecmp(s, "no") == 0)
-        return 0;
-    return -1;
+	if (strcasecmp(s, "true") == 0 || strcasecmp(s, "on") == 0 || strcasecmp(s, "yes") == 0)
+		return 1;
+	else if (strcasecmp(s, "false") == 0 || strcasecmp(s, "off") == 0 || strcasecmp(s, "no") == 0)
+		return 0;
+	return -1;
 }
 
 static void cfg_init_defaults(cfg_t *cfg)
 {
-    int i;
+	int i;
 
-    for(i = 0; cfg->opts[i].name; i++)
-    {
-        /* libConfuse doesn't handle default values for "simple" options */
-        if(cfg->opts[i].simple_value.ptr || is_set(CFGF_NODEFAULT, cfg->opts[i].flags))
-            continue;
+	for (i = 0; cfg->opts[i].name; i++) {
+		/* libConfuse doesn't handle default values for "simple" options */
+		if (cfg->opts[i].simple_value.ptr || is_set(CFGF_NODEFAULT, cfg->opts[i].flags))
+			continue;
 
-        if(cfg->opts[i].type != CFGT_SEC)
-        {
-            cfg->opts[i].flags |= CFGF_DEFINIT;
+		if (cfg->opts[i].type != CFGT_SEC) {
+			cfg->opts[i].flags |= CFGF_DEFINIT;
 
-            if(is_set(CFGF_LIST, cfg->opts[i].flags) ||
-               cfg->opts[i].def.parsed)
-            {
-                int xstate, ret;
+			if (is_set(CFGF_LIST, cfg->opts[i].flags) || cfg->opts[i].def.parsed) {
+				int xstate, ret;
 
-                /* If it's a list, but no default value was given,
-                 * keep the option uninitialized.
-                 */
-                if(cfg->opts[i].def.parsed == 0 ||
-                   cfg->opts[i].def.parsed[0] == 0)
-                    continue;
+				/* If it's a list, but no default value was given,
+				 * keep the option uninitialized.
+				 */
+				if (cfg->opts[i].def.parsed == 0 || cfg->opts[i].def.parsed[0] == 0)
+					continue;
 
-                /* setup scanning from the string specified for the
-                 * "default" value, force the correct state and option
-                 */
+				/* setup scanning from the string specified for the
+				 * "default" value, force the correct state and option
+				 */
 
-                if(is_set(CFGF_LIST, cfg->opts[i].flags))
-                    /* lists must be surrounded by {braces} */
-                    xstate = 3;
-                else if(cfg->opts[i].type == CFGT_FUNC)
-                    xstate = 0;
-                else
-                    xstate = 2;
+				if (is_set(CFGF_LIST, cfg->opts[i].flags))
+					/* lists must be surrounded by {braces} */
+					xstate = 3;
+				else if (cfg->opts[i].type == CFGT_FUNC)
+					xstate = 0;
+				else
+					xstate = 2;
 
-                cfg_scan_string_begin(cfg->opts[i].def.parsed);
-                do
-                {
-                    ret = cfg_parse_internal(cfg, 1, xstate, &cfg->opts[i]);
-                    xstate = -1;
-                } while(ret == STATE_CONTINUE);
-                cfg_scan_string_end();
-                if(ret == STATE_ERROR)
-                {
-                    /*
-                     * If there was an error parsing the default string,
-                     * the initialization of the default value could be
-                     * inconsistent or empty. What to do? It's a
-                     * programming error and not an end user input
-                     * error. Lets print a message and abort...
-                     */
-                    fprintf(stderr, "Parse error in default value '%s'"
-                            " for option '%s'\n",
-                            cfg->opts[i].def.parsed, cfg->opts[i].name);
-                    fprintf(stderr, "Check your initialization macros and the"
-                            " libConfuse documentation\n");
-                    abort();
-                }
-            }
-            else
-            {
-                switch(cfg->opts[i].type)
-                {
-                    case CFGT_INT:
-                        cfg_opt_setnint(&cfg->opts[i],
-                                        cfg->opts[i].def.number, 0);
-                        break;
-                    case CFGT_FLOAT:
-                        cfg_opt_setnfloat(&cfg->opts[i],
-                                          cfg->opts[i].def.fpnumber, 0);
-                        break;
-                    case CFGT_BOOL:
-                        cfg_opt_setnbool(&cfg->opts[i],
-                                         cfg->opts[i].def.boolean, 0);
-                        break;
-                    case CFGT_STR:
-                        cfg_opt_setnstr(&cfg->opts[i],
-                                        cfg->opts[i].def.string, 0);
-                        break;
-                    case CFGT_FUNC:
-                    case CFGT_PTR:
-                        break;
-                    default:
-                        cfg_error(cfg,
-                                  "internal error in cfg_init_defaults(%s)",
-                                  cfg->opts[i].name);
-                        break;
-                }
-            }
+				cfg_scan_string_begin(cfg->opts[i].def.parsed);
+				do {
+					ret = cfg_parse_internal(cfg, 1, xstate, &cfg->opts[i]);
+					xstate = -1;
+				} while (ret == STATE_CONTINUE);
+				cfg_scan_string_end();
+				if (ret == STATE_ERROR) {
+					/*
+					 * If there was an error parsing the default string,
+					 * the initialization of the default value could be
+					 * inconsistent or empty. What to do? It's a
+					 * programming error and not an end user input
+					 * error. Lets print a message and abort...
+					 */
+					fprintf(stderr, "Parse error in default value '%s'"
+						" for option '%s'\n", cfg->opts[i].def.parsed, cfg->opts[i].name);
+					fprintf(stderr, "Check your initialization macros and the" " libConfuse documentation\n");
+					abort();
+				}
+			} else {
+				switch (cfg->opts[i].type) {
+				case CFGT_INT:
+					cfg_opt_setnint(&cfg->opts[i], cfg->opts[i].def.number, 0);
+					break;
+				case CFGT_FLOAT:
+					cfg_opt_setnfloat(&cfg->opts[i], cfg->opts[i].def.fpnumber, 0);
+					break;
+				case CFGT_BOOL:
+					cfg_opt_setnbool(&cfg->opts[i], cfg->opts[i].def.boolean, 0);
+					break;
+				case CFGT_STR:
+					cfg_opt_setnstr(&cfg->opts[i], cfg->opts[i].def.string, 0);
+					break;
+				case CFGT_FUNC:
+				case CFGT_PTR:
+					break;
+				default:
+					cfg_error(cfg, "internal error in cfg_init_defaults(%s)", cfg->opts[i].name);
+					break;
+				}
+			}
 
-            /* The default value should only be returned if no value
-             * is given in the configuration file, so we set the RESET
-             * flag here. When/If cfg_setopt() is called, the value(s)
-             * will be freed and the flag unset.
-             */
-            cfg->opts[i].flags |= CFGF_RESET;
-        } /* end if cfg->opts[i].type != CFGT_SEC */
-        else if(!is_set(CFGF_MULTI, cfg->opts[i].flags))
-        {
-            cfg_setopt(cfg, &cfg->opts[i], 0);
-            cfg->opts[i].flags |= CFGF_DEFINIT;
-        }
-    }
+			/* The default value should only be returned if no value
+			 * is given in the configuration file, so we set the RESET
+			 * flag here. When/If cfg_setopt() is called, the value(s)
+			 * will be freed and the flag unset.
+			 */
+			cfg->opts[i].flags |= CFGF_RESET;
+		} /* end if cfg->opts[i].type != CFGT_SEC */
+		else if (!is_set(CFGF_MULTI, cfg->opts[i].flags)) {
+			cfg_setopt(cfg, &cfg->opts[i], 0);
+			cfg->opts[i].flags |= CFGF_DEFINIT;
+		}
+	}
 }
 
-DLLIMPORT cfg_value_t *
-cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
+DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 {
-    cfg_value_t *val = 0;
-    int b;
-    const char *s;
-    double f;
-    long int i;
-    void *p;
-    char *endptr;
+	cfg_value_t *val = 0;
+	int b;
+	const char *s;
+	double f;
+	long int i;
+	void *p;
+	char *endptr;
 
-    assert(cfg && opt);
+	assert(cfg && opt);
 
-    if(opt->simple_value.ptr)
-    {
-        assert(opt->type != CFGT_SEC);
-        val = (cfg_value_t *)opt->simple_value.ptr;
-    }
-    else
-    {
-        if(is_set(CFGF_RESET, opt->flags))
-        {
-            cfg_free_value(opt);
-            opt->flags &= ~CFGF_RESET;
-        }
+	if (opt->simple_value.ptr) {
+		assert(opt->type != CFGT_SEC);
+		val = (cfg_value_t *)opt->simple_value.ptr;
+	} else {
+		if (is_set(CFGF_RESET, opt->flags)) {
+			cfg_free_value(opt);
+			opt->flags &= ~CFGF_RESET;
+		}
 
-        if(opt->nvalues == 0 || is_set(CFGF_MULTI, opt->flags) ||
-           is_set(CFGF_LIST, opt->flags))
-        {
-            val = 0;
-            if(opt->type == CFGT_SEC && is_set(CFGF_TITLE, opt->flags))
-            {
-                unsigned int i;
+		if (opt->nvalues == 0 || is_set(CFGF_MULTI, opt->flags) || is_set(CFGF_LIST, opt->flags)) {
+			val = 0;
+			if (opt->type == CFGT_SEC && is_set(CFGF_TITLE, opt->flags)) {
+				unsigned int i;
 
-                /* Check if there already is a section with the same title.
-                 */
+				/* Check if there already is a section with the same title.
+				 */
 
-		/* Assert that there are either no sections at all, or a
-		 * non-NULL section title. */
-                assert(opt->nvalues == 0 || value);
+				/* Assert that there are either no sections at all, or a
+				 * non-NULL section title. */
+				assert(opt->nvalues == 0 || value);
 
-                for(i = 0; i < opt->nvalues && val == NULL; i++)
-                {
-                    cfg_t *sec = opt->values[i]->section;
-                    if(is_set(CFGF_NOCASE, cfg->flags))
-                    {
-                        if(strcasecmp(value, sec->title) == 0)
-                            val = opt->values[i];
-                    }
-                    else
-                    {
-                        if(strcmp(value, sec->title) == 0)
-                            val = opt->values[i];
-                    }
-                }
-                if(val && is_set(CFGF_NO_TITLE_DUPES, opt->flags))
-                {
-                    cfg_error(cfg, _("found duplicate title '%s'"), value);
-                    return 0;
-                }
-            }
-            if(val == NULL)
-                val = cfg_addval(opt);
-        }
-        else
-            val = opt->values[0];
-    }
+				for (i = 0; i < opt->nvalues && val == NULL; i++) {
+					cfg_t *sec = opt->values[i]->section;
 
-    switch(opt->type)
-    {
-        case CFGT_INT:
-            if(opt->parsecb)
-            {
-                if((*opt->parsecb)(cfg, opt, value, &i) != 0)
-                    return 0;
-            }
-            else
-            {
-                i = strtol(value, &endptr, 0);
-                if(*endptr != '\0')
-                {
-                    cfg_error(cfg, _("invalid integer value for option '%s'"),
-                              opt->name);
-                    return 0;
-                }
-                if(errno == ERANGE)
-                {
-                    cfg_error(cfg,
-                          _("integer value for option '%s' is out of range"),
-                              opt->name);
-                    return 0;
-                }
-            }
-            val->number = i;
-            break;
+					if (is_set(CFGF_NOCASE, cfg->flags)) {
+						if (strcasecmp(value, sec->title) == 0)
+							val = opt->values[i];
+					} else {
+						if (strcmp(value, sec->title) == 0)
+							val = opt->values[i];
+					}
+				}
+				if (val && is_set(CFGF_NO_TITLE_DUPES, opt->flags)) {
+					cfg_error(cfg, _("found duplicate title '%s'"), value);
+					return 0;
+				}
+			}
+			if (val == NULL)
+				val = cfg_addval(opt);
+		} else
+			val = opt->values[0];
+	}
 
-        case CFGT_FLOAT:
-            if(opt->parsecb)
-            {
-                if((*opt->parsecb)(cfg, opt, value, &f) != 0)
-                    return 0;
-            }
-            else
-            {
-                f = strtod(value, &endptr);
-                if(*endptr != '\0')
-                {
-                    cfg_error(cfg,
-                          _("invalid floating point value for option '%s'"),
-                              opt->name);
-                    return 0;
-                }
-                if(errno == ERANGE)
-                {
-                    cfg_error(cfg,
-                  _("floating point value for option '%s' is out of range"),
-                              opt->name);
-                    return 0;
-                }
-            }
-            val->fpnumber = f;
-            break;
+	switch (opt->type) {
+	case CFGT_INT:
+		if (opt->parsecb) {
+			if ((*opt->parsecb) (cfg, opt, value, &i) != 0)
+				return 0;
+		} else {
+			i = strtol(value, &endptr, 0);
+			if (*endptr != '\0') {
+				cfg_error(cfg, _("invalid integer value for option '%s'"), opt->name);
+				return 0;
+			}
+			if (errno == ERANGE) {
+				cfg_error(cfg, _("integer value for option '%s' is out of range"), opt->name);
+				return 0;
+			}
+		}
+		val->number = i;
+		break;
 
-        case CFGT_STR:
-            if(opt->parsecb)
-            {
-                s = 0;
-                if((*opt->parsecb)(cfg, opt, value, &s) != 0)
-                    return 0;
-            }
-            else
-            {
-                s = value;
-            }
-            free(val->string);
-            val->string = strdup(s);
-            break;
+	case CFGT_FLOAT:
+		if (opt->parsecb) {
+			if ((*opt->parsecb) (cfg, opt, value, &f) != 0)
+				return 0;
+		} else {
+			f = strtod(value, &endptr);
+			if (*endptr != '\0') {
+				cfg_error(cfg, _("invalid floating point value for option '%s'"), opt->name);
+				return 0;
+			}
+			if (errno == ERANGE) {
+				cfg_error(cfg, _("floating point value for option '%s' is out of range"), opt->name);
+				return 0;
+			}
+		}
+		val->fpnumber = f;
+		break;
 
-        case CFGT_SEC:
-            if(is_set(CFGF_MULTI, opt->flags) || val->section == 0)
-            {
-                if (val->section)
-                    val->section->path = 0;
-                cfg_free(val->section);
-                val->section = calloc(1, sizeof(cfg_t));
-                assert(val->section);
-                val->section->name = strdup(opt->name);
-                val->section->opts = cfg_dupopt_array(opt->subopts);
-                val->section->flags = cfg->flags;
-                val->section->filename = cfg->filename ? strdup(cfg->filename) : 0;
-                val->section->line = cfg->line;
-                val->section->errfunc = cfg->errfunc;
-                val->section->title = value ? strdup(value) : 0;
-            }
-            if(!is_set(CFGF_DEFINIT, opt->flags))
-                cfg_init_defaults(val->section);
-            break;
+	case CFGT_STR:
+		if (opt->parsecb) {
+			s = 0;
+			if ((*opt->parsecb) (cfg, opt, value, &s) != 0)
+				return 0;
+		} else {
+			s = value;
+		}
+		free(val->string);
+		val->string = strdup(s);
+		break;
 
-        case CFGT_BOOL:
-            if(opt->parsecb)
-            {
-                if((*opt->parsecb)(cfg, opt, value, &b) != 0)
-                    return 0;
-            }
-            else
-            {
-                b = cfg_parse_boolean(value);
-                if(b == -1)
-                {
-                    cfg_error(cfg, _("invalid boolean value for option '%s'"),
-                              opt->name);
-                    return 0;
-                }
-            }
-            val->boolean = (cfg_bool_t)b;
-            break;
+	case CFGT_SEC:
+		if (is_set(CFGF_MULTI, opt->flags) || val->section == 0) {
+			if (val->section)
+				val->section->path = 0;
+			cfg_free(val->section);
+			val->section = calloc(1, sizeof(cfg_t));
+			assert(val->section);
+			val->section->name = strdup(opt->name);
+			val->section->opts = cfg_dupopt_array(opt->subopts);
+			val->section->flags = cfg->flags;
+			val->section->filename = cfg->filename ? strdup(cfg->filename) : 0;
+			val->section->line = cfg->line;
+			val->section->errfunc = cfg->errfunc;
+			val->section->title = value ? strdup(value) : 0;
+		}
+		if (!is_set(CFGF_DEFINIT, opt->flags))
+			cfg_init_defaults(val->section);
+		break;
 
-        case CFGT_PTR:
-            assert(opt->parsecb);
-            if((*opt->parsecb)(cfg, opt, value, &p) != 0)
-                return 0;
-            val->ptr = p;
-            break;
+	case CFGT_BOOL:
+		if (opt->parsecb) {
+			if ((*opt->parsecb) (cfg, opt, value, &b) != 0)
+				return 0;
+		} else {
+			b = cfg_parse_boolean(value);
+			if (b == -1) {
+				cfg_error(cfg, _("invalid boolean value for option '%s'"), opt->name);
+				return 0;
+			}
+		}
+		val->boolean = (cfg_bool_t)b;
+		break;
 
-        default:
-            cfg_error(cfg, "internal error in cfg_setopt(%s, %s)",
-                      opt->name, value);
-            assert(0);
-            break;
-    }
-    return val;
+	case CFGT_PTR:
+		assert(opt->parsecb);
+		if ((*opt->parsecb) (cfg, opt, value, &p) != 0)
+			return 0;
+		val->ptr = p;
+		break;
+
+	default:
+		cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, value);
+		assert(0);
+		break;
+	}
+	return val;
 }
 
-DLLIMPORT int
-cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues, char **values)
+DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues, char **values)
 {
-    cfg_opt_t old;
-    unsigned int i;
+	cfg_opt_t old;
+	unsigned int i;
 
-    if(!opt || !nvalues)
-        return -1;
+	if (!opt || !nvalues)
+		return -1;
 
-    old = *opt;
-    opt->nvalues = 0;
-    opt->values = 0;
+	old = *opt;
+	opt->nvalues = 0;
+	opt->values = 0;
 
-    for(i = 0; i < nvalues; i++) {
-        if(cfg_setopt(cfg, opt, values[i]))
-            continue;
-        /* ouch, revert */
-        cfg_free_value(opt);
-        opt->nvalues = old.nvalues;
-        opt->values = old.values;
-        return -1;
-    }
+	for (i = 0; i < nvalues; i++) {
+		if (cfg_setopt(cfg, opt, values[i]))
+			continue;
+		/* ouch, revert */
+		cfg_free_value(opt);
+		opt->nvalues = old.nvalues;
+		opt->values = old.values;
+		return -1;
+	}
 
-    cfg_free_value(&old);
-    return 0;
+	cfg_free_value(&old);
+	return 0;
 }
 
-DLLIMPORT int
-cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, char **values)
+DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, char **values)
 {
-    cfg_opt_t *opt = cfg_getopt(cfg, name);
-    if(!opt)
-        return -1;
-    return cfg_opt_setmulti(cfg, opt, nvalues, values);
+	cfg_opt_t *opt = cfg_getopt(cfg, name);
+
+	if (!opt)
+		return -1;
+	return cfg_opt_setmulti(cfg, opt, nvalues, values);
 }
 
 /* searchpath */
 
 struct cfg_searchpath_t {
-    char *dir;               /**< directory to search */
-    cfg_searchpath_t *next;  /**< next in list */
+	char *dir;	     /**< directory to search */
+	cfg_searchpath_t *next;
+			     /**< next in list */
 };
 
 /* prepend a new cfg_searchpath_t to the linked list */
 
 DLLIMPORT int cfg_add_searchpath(cfg_t *cfg, const char *dir)
 {
-    cfg_searchpath_t *p;
-    char *d;
+	cfg_searchpath_t *p;
+	char *d;
 
-    assert(cfg && dir);
+	assert(cfg && dir);
 
-    if ((d = cfg_tilde_expand(dir)) == NULL) return CFG_PARSE_ERROR;
+	if ((d = cfg_tilde_expand(dir)) == NULL)
+		return CFG_PARSE_ERROR;
 
-    if ((p = malloc(sizeof(cfg_searchpath_t))) == NULL)
-    {
-	free(d);
-	return CFG_PARSE_ERROR;
-    }
+	if ((p = malloc(sizeof(cfg_searchpath_t))) == NULL) {
+		free(d);
+		return CFG_PARSE_ERROR;
+	}
 
-    p->next = cfg->path;
-    p->dir  = d;
-    
-    cfg->path = p;
+	p->next = cfg->path;
+	p->dir = d;
 
-    return CFG_SUCCESS;
+	cfg->path = p;
+
+	return CFG_SUCCESS;
 }
 
-DLLIMPORT cfg_errfunc_t cfg_set_error_function(cfg_t *cfg,
-                                               cfg_errfunc_t errfunc)
+DLLIMPORT cfg_errfunc_t cfg_set_error_function(cfg_t *cfg, cfg_errfunc_t errfunc)
 {
-    cfg_errfunc_t old;
+	cfg_errfunc_t old;
 
-    assert(cfg);
-    old = cfg->errfunc;
-    cfg->errfunc = errfunc;
-    return old;
+	assert(cfg);
+	old = cfg->errfunc;
+	cfg->errfunc = errfunc;
+	return old;
 }
 
 DLLIMPORT void cfg_error(cfg_t *cfg, const char *fmt, ...)
 {
-    va_list ap;
+	va_list ap;
 
-    va_start(ap, fmt);
+	va_start(ap, fmt);
 
-    if(cfg && cfg->errfunc)
-        (*cfg->errfunc)(cfg, fmt, ap);
-    else
-    {
-        if(cfg && cfg->filename && cfg->line)
-            fprintf(stderr, "%s:%d: ", cfg->filename, cfg->line);
-        else if(cfg && cfg->filename)
-            fprintf(stderr, "%s: ", cfg->filename);
-        vfprintf(stderr, fmt, ap);
-        fprintf(stderr, "\n");
-    }
+	if (cfg && cfg->errfunc)
+		(*cfg->errfunc) (cfg, fmt, ap);
+	else {
+		if (cfg && cfg->filename && cfg->line)
+			fprintf(stderr, "%s:%d: ", cfg->filename, cfg->line);
+		else if (cfg && cfg->filename)
+			fprintf(stderr, "%s: ", cfg->filename);
+		vfprintf(stderr, fmt, ap);
+		fprintf(stderr, "\n");
+	}
 
-    va_end(ap);
+	va_end(ap);
 }
 
 static int call_function(cfg_t *cfg, cfg_opt_t *opt, cfg_opt_t *funcopt)
 {
-    int ret;
-    const char **argv;
-    unsigned int i;
+	int ret;
+	const char **argv;
+	unsigned int i;
 
-    /* create a regular argv string vector and call
-     * the registered function
-     */
-    argv = calloc(funcopt->nvalues, sizeof(char *));
-    for(i = 0; i < funcopt->nvalues; i++)
-        argv[i] = funcopt->values[i]->string;
-    ret = (*opt->func)(cfg, opt, funcopt->nvalues, argv);
-    cfg_free_value(funcopt);
-    free(argv);
-    return ret;
+	/* create a regular argv string vector and call
+	 * the registered function
+	 */
+	argv = calloc(funcopt->nvalues, sizeof(char *));
+	for (i = 0; i < funcopt->nvalues; i++)
+		argv[i] = funcopt->values[i]->string;
+	ret = (*opt->func) (cfg, opt, funcopt->nvalues, argv);
+	cfg_free_value(funcopt);
+	free(argv);
+	return ret;
 }
 
-static int cfg_parse_internal(cfg_t *cfg, int level,
-                              int force_state, cfg_opt_t *force_opt)
+static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t *force_opt)
 {
-    int state = 0;
-    char *opttitle = 0;
-    cfg_opt_t *opt = 0;
-    cfg_value_t *val = 0;
-    cfg_opt_t funcopt = CFG_STR(0, 0, 0);
-    int num_values = 0; /* number of values found for a list option */
-    int rc;
+	int state = 0;
+	char *opttitle = 0;
+	cfg_opt_t *opt = 0;
+	cfg_value_t *val = 0;
+	cfg_opt_t funcopt = CFG_STR(0, 0, 0);
+	int num_values = 0;	/* number of values found for a list option */
+	int rc;
 
-    if(force_state != -1)
-        state = force_state;
-    if(force_opt)
-        opt = force_opt;
+	if (force_state != -1)
+		state = force_state;
+	if (force_opt)
+		opt = force_opt;
 
-    while(1)
-    {
-        int tok = cfg_yylex(cfg);
+	while (1) {
+		int tok = cfg_yylex(cfg);
 
-        if(tok == 0)
-        {
-            /* lexer.l should have called cfg_error */
-            return STATE_ERROR;
-        }
+		if (tok == 0) {
+			/* lexer.l should have called cfg_error */
+			return STATE_ERROR;
+		}
 
-        if(tok == EOF)
-        {
-            if(state != 0)
-            {
-                cfg_error(cfg, _("premature end of file"));
-                return STATE_ERROR;
-            }
-            return STATE_EOF;
-        }
+		if (tok == EOF) {
+			if (state != 0) {
+				cfg_error(cfg, _("premature end of file"));
+				return STATE_ERROR;
+			}
+			return STATE_EOF;
+		}
 
-        switch(state)
-        {
-            case 0: /* expecting an option name */
-                if(tok == '}')
-                {
-                    if(level == 0)
-                    {
-                        cfg_error(cfg, _("unexpected closing brace"));
-                        return STATE_ERROR;
-                    }
-                    return STATE_EOF;
-                }
-                if(tok != CFGT_STR)
-                {
-                    cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
-                    return STATE_ERROR;
-                }
-                opt = cfg_getopt(cfg, cfg_yylval);
-                if(opt == 0) {
-                    if(cfg->flags & CFGF_IGNORE_UNKNOWN)
-                        opt = cfg_getopt(cfg, "__unknown");
-                    if(opt == 0)       
-                        return STATE_ERROR;
-                }
-                if(opt->type == CFGT_SEC)
-                {
-                    if(is_set(CFGF_TITLE, opt->flags))
-                        state = 6;
-                    else
-                        state = 5;
-                }
-                else if(opt->type == CFGT_FUNC)
-                {
-                    state = 7;
-                }
-                else
-                    state = 1;
-                break;
+		switch (state) {
+		case 0:	/* expecting an option name */
+			if (tok == '}') {
+				if (level == 0) {
+					cfg_error(cfg, _("unexpected closing brace"));
+					return STATE_ERROR;
+				}
+				return STATE_EOF;
+			}
+			if (tok != CFGT_STR) {
+				cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
+				return STATE_ERROR;
+			}
+			opt = cfg_getopt(cfg, cfg_yylval);
+			if (opt == 0) {
+				if (cfg->flags & CFGF_IGNORE_UNKNOWN)
+					opt = cfg_getopt(cfg, "__unknown");
+				if (opt == 0)
+					return STATE_ERROR;
+			}
+			if (opt->type == CFGT_SEC) {
+				if (is_set(CFGF_TITLE, opt->flags))
+					state = 6;
+				else
+					state = 5;
+			} else if (opt->type == CFGT_FUNC) {
+				state = 7;
+			} else
+				state = 1;
+			break;
 
-            case 1: /* expecting an equal sign or plus-equal sign */
-                if(tok == '+')
-                {
-                    if(!is_set(CFGF_LIST, opt->flags))
-                    {
-                        cfg_error(cfg,
-                                  _("attempt to append to non-list option '%s'"),
-                                  opt->name);
-                        return STATE_ERROR;
-                    }
-                    /* Even if the reset flag was set by
-                     * cfg_init_defaults, appending to the defaults
-                     * should be ok.
-                     */
-                    opt->flags &= ~CFGF_RESET;
-                }
-                else if(tok == '=')
-                {
-                    /* set the (temporary) reset flag to clear the old
-                     * values, since we obviously didn't want to append */
-                    opt->flags |= CFGF_RESET;
-                }
-                else
-                {
-                    cfg_error(cfg, _("missing equal sign after option '%s'"),
-                              opt->name);
-                    return STATE_ERROR;
-                }
-                if(is_set(CFGF_LIST, opt->flags))
-                {
-                    state = 3;
-                    num_values = 0;
-                } else
-                    state = 2;
-                break;
+		case 1:	/* expecting an equal sign or plus-equal sign */
+			if (tok == '+') {
+				if (!is_set(CFGF_LIST, opt->flags)) {
+					cfg_error(cfg, _("attempt to append to non-list option '%s'"), opt->name);
+					return STATE_ERROR;
+				}
+				/* Even if the reset flag was set by
+				 * cfg_init_defaults, appending to the defaults
+				 * should be ok.
+				 */
+				opt->flags &= ~CFGF_RESET;
+			} else if (tok == '=') {
+				/* set the (temporary) reset flag to clear the old
+				 * values, since we obviously didn't want to append */
+				opt->flags |= CFGF_RESET;
+			} else {
+				cfg_error(cfg, _("missing equal sign after option '%s'"), opt->name);
+				return STATE_ERROR;
+			}
+			if (is_set(CFGF_LIST, opt->flags)) {
+				state = 3;
+				num_values = 0;
+			} else
+				state = 2;
+			break;
 
-            case 2: /* expecting an option value */
-                if(tok == '}' && is_set(CFGF_LIST, opt->flags))
-                {
-                    state = 0;
-                    if(num_values == 0 && is_set(CFGF_RESET, opt->flags))
-                        /* Reset flags was set, and the empty list was
-                         * specified. Free all old values. */
-                        cfg_free_value(opt);
-                    break;
-                }
+		case 2:	/* expecting an option value */
+			if (tok == '}' && is_set(CFGF_LIST, opt->flags)) {
+				state = 0;
+				if (num_values == 0 && is_set(CFGF_RESET, opt->flags))
+					/* Reset flags was set, and the empty list was
+					 * specified. Free all old values. */
+					cfg_free_value(opt);
+				break;
+			}
 
-                if(tok != CFGT_STR)
-                {
-                    cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
-                    return STATE_ERROR;
-                }
+			if (tok != CFGT_STR) {
+				cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
+				return STATE_ERROR;
+			}
 
-                if(cfg_setopt(cfg, opt, cfg_yylval) == 0)
-                    return STATE_ERROR;
-                if(opt->validcb && (*opt->validcb)(cfg, opt) != 0)
-                    return STATE_ERROR;
-                if(is_set(CFGF_LIST, opt->flags))
-                {
-                    ++num_values;
-                    state = 4;
-                }
-                else
-                    state = 0;
-                break;
+			if (cfg_setopt(cfg, opt, cfg_yylval) == 0)
+				return STATE_ERROR;
+			if (opt->validcb && (*opt->validcb) (cfg, opt) != 0)
+				return STATE_ERROR;
+			if (is_set(CFGF_LIST, opt->flags)) {
+				++num_values;
+				state = 4;
+			} else
+				state = 0;
+			break;
 
-            case 3: /* expecting an opening brace for a list option */
-                if(tok != '{')
-                {
-                    if(tok != CFGT_STR)
-                    {
-                        cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
-                        return STATE_ERROR;
-                    }
+		case 3:	/* expecting an opening brace for a list option */
+			if (tok != '{') {
+				if (tok != CFGT_STR) {
+					cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
+					return STATE_ERROR;
+				}
 
-                    if(cfg_setopt(cfg, opt, cfg_yylval) == 0)
-                        return STATE_ERROR;
-                    if(opt->validcb && (*opt->validcb)(cfg, opt) != 0)
-                        return STATE_ERROR;
-                    ++num_values;
-                    state = 0;
-                }
-                else
-                    state = 2;
-                break;
+				if (cfg_setopt(cfg, opt, cfg_yylval) == 0)
+					return STATE_ERROR;
+				if (opt->validcb && (*opt->validcb) (cfg, opt) != 0)
+					return STATE_ERROR;
+				++num_values;
+				state = 0;
+			} else
+				state = 2;
+			break;
 
-            case 4: /* expecting a separator for a list option, or
-                     * closing (list) brace */
-                if(tok == ',')
-                    state = 2;
-                else if(tok == '}')
-                {
-                    state = 0;
-                    if(opt->validcb && (*opt->validcb)(cfg, opt) != 0)
-                        return STATE_ERROR;
-                }
-                else
-                {
-                    cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
-                    return STATE_ERROR;
-                }
-                break;
+		case 4:	/* expecting a separator for a list option, or
+				 * closing (list) brace */
+			if (tok == ',')
+				state = 2;
+			else if (tok == '}') {
+				state = 0;
+				if (opt->validcb && (*opt->validcb) (cfg, opt) != 0)
+					return STATE_ERROR;
+			} else {
+				cfg_error(cfg, _("unexpected token '%s'"), cfg_yylval);
+				return STATE_ERROR;
+			}
+			break;
 
-            case 5: /* expecting an opening brace for a section */
-                if(tok != '{')
-                {
-                    cfg_error(cfg, _("missing opening brace for section '%s'"),
-                              opt->name);
-                    return STATE_ERROR;
-                }
+		case 5:	/* expecting an opening brace for a section */
+			if (tok != '{') {
+				cfg_error(cfg, _("missing opening brace for section '%s'"), opt->name);
+				return STATE_ERROR;
+			}
 
-                val = cfg_setopt(cfg, opt, opttitle);
-                free(opttitle);
-                opttitle = 0;
-                if(!val)
-                    return STATE_ERROR;
+			val = cfg_setopt(cfg, opt, opttitle);
+			free(opttitle);
+			opttitle = 0;
+			if (!val)
+				return STATE_ERROR;
 
-		val->section->path = cfg->path;
-                val->section->line = cfg->line;
-		val->section->errfunc = cfg->errfunc;
-                rc = cfg_parse_internal(val->section, level+1,-1,0);
-                cfg->line = val->section->line;
-                if(rc != STATE_EOF)
-                    return STATE_ERROR;
-                if(opt->validcb && (*opt->validcb)(cfg, opt) != 0)
-                    return STATE_ERROR;
-                state = 0;
-                break;
+			val->section->path = cfg->path;
+			val->section->line = cfg->line;
+			val->section->errfunc = cfg->errfunc;
+			rc = cfg_parse_internal(val->section, level + 1, -1, 0);
+			cfg->line = val->section->line;
+			if (rc != STATE_EOF)
+				return STATE_ERROR;
+			if (opt->validcb && (*opt->validcb) (cfg, opt) != 0)
+				return STATE_ERROR;
+			state = 0;
+			break;
 
-            case 6: /* expecting a title for a section */
-                if(tok != CFGT_STR)
-                {
-                    cfg_error(cfg, _("missing title for section '%s'"),
-                              opt->name);
-                    return STATE_ERROR;
-                }
-                else
-                    opttitle = strdup(cfg_yylval);
-                state = 5;
-                break;
+		case 6:	/* expecting a title for a section */
+			if (tok != CFGT_STR) {
+				cfg_error(cfg, _("missing title for section '%s'"), opt->name);
+				return STATE_ERROR;
+			} else
+				opttitle = strdup(cfg_yylval);
+			state = 5;
+			break;
 
-            case 7: /* expecting an opening parenthesis for a function */
-                if(tok != '(')
-                {
-                    cfg_error(cfg, _("missing parenthesis for function '%s'"),
-                              opt->name);
-                    return STATE_ERROR;
-                }
-                state = 8;
-                break;
+		case 7:	/* expecting an opening parenthesis for a function */
+			if (tok != '(') {
+				cfg_error(cfg, _("missing parenthesis for function '%s'"), opt->name);
+				return STATE_ERROR;
+			}
+			state = 8;
+			break;
 
-            case 8: /* expecting a function parameter or a closing paren */
-                if(tok == ')')
-                {
-                    int ret = call_function(cfg, opt, &funcopt);
-                    if(ret != 0)
-                        return STATE_ERROR;
-                    state = 0;
-                }
-                else if(tok == CFGT_STR)
-                {
-                    val = cfg_addval(&funcopt);
-                    val->string = strdup(cfg_yylval);
-                    state = 9;
-                }
-                else
-                {
-                    cfg_error(cfg, _("syntax error in call of function '%s'"),
-                              opt->name);
-                    return STATE_ERROR;
-                }
-                break;
+		case 8:	/* expecting a function parameter or a closing paren */
+			if (tok == ')') {
+				int ret = call_function(cfg, opt, &funcopt);
 
-            case 9: /* expecting a comma in a function or a closing paren */
-                if(tok == ')')
-                {
-                    int ret = call_function(cfg, opt, &funcopt);
-                    if(ret != 0)
-                        return STATE_ERROR;
-                    state = 0;
-                }
-                else if(tok == ',')
-                    state = 8;
-                else
-                {
-                    cfg_error(cfg, _("syntax error in call of function '%s'"),
-                              opt->name);
-                    return STATE_ERROR;
-                }
-                break;
+				if (ret != 0)
+					return STATE_ERROR;
+				state = 0;
+			} else if (tok == CFGT_STR) {
+				val = cfg_addval(&funcopt);
+				val->string = strdup(cfg_yylval);
+				state = 9;
+			} else {
+				cfg_error(cfg, _("syntax error in call of function '%s'"), opt->name);
+				return STATE_ERROR;
+			}
+			break;
 
-            default:
-                /* missing state, internal error, abort */
-                assert(0);
-        }
-    }
+		case 9:	/* expecting a comma in a function or a closing paren */
+			if (tok == ')') {
+				int ret = call_function(cfg, opt, &funcopt);
 
-    return STATE_EOF;
+				if (ret != 0)
+					return STATE_ERROR;
+				state = 0;
+			} else if (tok == ',')
+				state = 8;
+			else {
+				cfg_error(cfg, _("syntax error in call of function '%s'"), opt->name);
+				return STATE_ERROR;
+			}
+			break;
+
+		default:
+			/* missing state, internal error, abort */
+			assert(0);
+		}
+	}
+
+	return STATE_EOF;
 }
 
 DLLIMPORT int cfg_parse_fp(cfg_t *cfg, FILE *fp)
 {
-    int ret;
-    assert(cfg && fp);
+	int ret;
 
-    if(cfg->filename == 0)
-        cfg->filename = strdup("FILE");
-    cfg->line = 1;
+	assert(cfg && fp);
 
-    cfg_yyin = fp;
-    cfg_scan_fp_begin(cfg_yyin);
-    ret = cfg_parse_internal(cfg, 0, -1, 0);
-    cfg_scan_fp_end();
-    if(ret == STATE_ERROR)
-        return CFG_PARSE_ERROR;
-    return CFG_SUCCESS;
+	if (cfg->filename == 0)
+		cfg->filename = strdup("FILE");
+	cfg->line = 1;
+
+	cfg_yyin = fp;
+	cfg_scan_fp_begin(cfg_yyin);
+	ret = cfg_parse_internal(cfg, 0, -1, 0);
+	cfg_scan_fp_end();
+	if (ret == STATE_ERROR)
+		return CFG_PARSE_ERROR;
+	return CFG_SUCCESS;
 }
 
 static char *cfg_make_fullpath(const char *dir, const char *file)
 {
-    int np;
-    char *path;
-    size_t len;
+	int np;
+	char *path;
+	size_t len;
 
-    assert(dir && file);
+	assert(dir && file);
 
-    len = strlen(dir) + strlen(file) + 2;
-    path = malloc(len);
+	len = strlen(dir) + strlen(file) + 2;
+	path = malloc(len);
 
-    assert(path);
+	assert(path);
 
-    np = snprintf(path, len, "%s/%s", dir, file);
+	np = snprintf(path, len, "%s/%s", dir, file);
 
-    /* 
-     * np is the number of characters that would have
-     * been printed if there was enough room in path.
-     * if np >= n then the snprintf() was truncated
-     * (which must be a bug).
-     */
-    assert(np < len);
+	/*
+	 * np is the number of characters that would have
+	 * been printed if there was enough room in path.
+	 * if np >= n then the snprintf() was truncated
+	 * (which must be a bug).
+	 */
+	assert(np < len);
 
-    return path;
+	return path;
 }
 
 DLLIMPORT char *cfg_searchpath(cfg_searchpath_t *p, const char *file)
 {
-    char *fullpath;
-    struct stat st;
-    int err;
+	char *fullpath;
+	struct stat st;
+	int err;
 
-    if (!p) return NULL;
+	if (!p)
+		return NULL;
 
-    if ((fullpath = cfg_searchpath(p->next, file)) != NULL)
-        return fullpath;
+	if ((fullpath = cfg_searchpath(p->next, file)) != NULL)
+		return fullpath;
 
-    if ((fullpath = cfg_make_fullpath(p->dir, file)) == NULL)
-        return NULL;
+	if ((fullpath = cfg_make_fullpath(p->dir, file)) == NULL)
+		return NULL;
 
 #ifdef HAVE_SYS_STAT_H
 
-    err = stat((const char*)fullpath, &st);
-    if ((!err) && S_ISREG(st.st_mode)) return fullpath;
+	err = stat((const char *)fullpath, &st);
+	if ((!err) && S_ISREG(st.st_mode))
+		return fullpath;
 
 #else
 
-    /* needs an alternative check here for win32 */
+	/* needs an alternative check here for win32 */
 
 #endif
 
-    free(fullpath);
-    return NULL;
+	free(fullpath);
+	return NULL;
 }
 
 DLLIMPORT int cfg_parse(cfg_t *cfg, const char *filename)
 {
-    int ret;
-    FILE *fp;
+	int ret;
+	FILE *fp;
 
-    assert(cfg && filename);
+	assert(cfg && filename);
 
-    if (cfg->path)
-    {
-	char *f;
+	if (cfg->path) {
+		char *f;
 
-	if ((f = cfg_searchpath(cfg->path, filename)) == NULL)
-	    return CFG_FILE_ERROR;
+		if ((f = cfg_searchpath(cfg->path, filename)) == NULL)
+			return CFG_FILE_ERROR;
 
-	free(cfg->filename);
-	cfg->filename = f;
+		free(cfg->filename);
+		cfg->filename = f;
 
-    }
-    else
-    {
-	free(cfg->filename);
-	cfg->filename = cfg_tilde_expand(filename);
-    }
+	} else {
+		free(cfg->filename);
+		cfg->filename = cfg_tilde_expand(filename);
+	}
 
-    if ((fp = fopen(cfg->filename,"r")) == 0)
-        return CFG_FILE_ERROR;
+	if ((fp = fopen(cfg->filename, "r")) == 0)
+		return CFG_FILE_ERROR;
 
-    ret = cfg_parse_fp(cfg, fp);
-    fclose(fp);
+	ret = cfg_parse_fp(cfg, fp);
+	fclose(fp);
 
-    return ret;
+	return ret;
 }
 
 DLLIMPORT int cfg_parse_buf(cfg_t *cfg, const char *buf)
 {
-    int ret;
+	int ret;
 
-    assert(cfg);
-    if(buf == 0)
-        return CFG_SUCCESS;
+	assert(cfg);
+	if (buf == 0)
+		return CFG_SUCCESS;
 
-    free(cfg->filename);
-    cfg->filename = strdup("[buf]");
-    cfg->line = 1;
+	free(cfg->filename);
+	cfg->filename = strdup("[buf]");
+	cfg->line = 1;
 
-    cfg_scan_string_begin(buf);
-    ret = cfg_parse_internal(cfg, 0, -1, 0);
-    cfg_scan_string_end();
-    if(ret == STATE_ERROR)
-        return CFG_PARSE_ERROR;
-    return CFG_SUCCESS;
+	cfg_scan_string_begin(buf);
+	ret = cfg_parse_internal(cfg, 0, -1, 0);
+	cfg_scan_string_end();
+	if (ret == STATE_ERROR)
+		return CFG_PARSE_ERROR;
+	return CFG_SUCCESS;
 }
 
 DLLIMPORT cfg_t *cfg_init(cfg_opt_t *opts, cfg_flag_t flags)
 {
-    cfg_t *cfg;
+	cfg_t *cfg;
 
-    cfg = calloc(1, sizeof(cfg_t));
-    assert(cfg);
+	cfg = calloc(1, sizeof(cfg_t));
+	assert(cfg);
 
-    cfg->name = strdup("root");
-    cfg->opts = cfg_dupopt_array(opts);
-    cfg->flags = flags;
-    cfg->filename = 0;
-    cfg->line = 0;
-    cfg->errfunc = 0;
+	cfg->name = strdup("root");
+	cfg->opts = cfg_dupopt_array(opts);
+	cfg->flags = flags;
+	cfg->filename = 0;
+	cfg->line = 0;
+	cfg->errfunc = 0;
 
-    cfg_init_defaults(cfg);
+	cfg_init_defaults(cfg);
 
 #if defined(ENABLE_NLS) && defined(HAVE_GETTEXT)
-    setlocale(LC_MESSAGES, "");
-    setlocale(LC_CTYPE, "");
-    bindtextdomain(PACKAGE, LOCALEDIR);
+	setlocale(LC_MESSAGES, "");
+	setlocale(LC_CTYPE, "");
+	bindtextdomain(PACKAGE, LOCALEDIR);
 #endif
 
-    return cfg;
+	return cfg;
 }
 
 DLLIMPORT char *cfg_tilde_expand(const char *filename)
 {
-    char *expanded = 0;
+	char *expanded = 0;
 
 #ifndef _WIN32
-    /* do tilde expansion
-     */
-    if(filename[0] == '~')
-    {
-        struct passwd *passwd = 0;
-        const char *file = 0;
+	/* Do tilde expansion */
+	if (filename[0] == '~') {
+		struct passwd *passwd = 0;
+		const char *file = 0;
 
-        if(filename[1] == '/' || filename[1] == 0)
-        {
-            /* ~ or ~/path */
-            passwd = getpwuid(geteuid());
-            file = filename + 1;
-        }
-        else
-        {
-            /* ~user or ~user/path */
-            char *user;
+		if (filename[1] == '/' || filename[1] == 0) {
+			/* ~ or ~/path */
+			passwd = getpwuid(geteuid());
+			file = filename + 1;
+		} else {
+			/* ~user or ~user/path */
+			char *user;
 
-            file = strchr(filename, '/');
-            if(file == 0)
-                file = filename + strlen(filename);
-            user = malloc(file - filename);
-            strncpy(user, filename + 1, file - filename - 1);
-            passwd = getpwnam(user);
-            free(user);
-        }
+			file = strchr(filename, '/');
+			if (file == 0)
+				file = filename + strlen(filename);
+			user = malloc(file - filename);
+			strncpy(user, filename + 1, file - filename - 1);
+			passwd = getpwnam(user);
+			free(user);
+		}
 
-        if(passwd)
-        {
-            expanded = malloc(strlen(passwd->pw_dir) + strlen(file) + 1);
-            strcpy(expanded, passwd->pw_dir);
-            strcat(expanded, file);
-        }
-    }
+		if (passwd) {
+			expanded = malloc(strlen(passwd->pw_dir) + strlen(file) + 1);
+			strcpy(expanded, passwd->pw_dir);
+			strcat(expanded, file);
+		}
+	}
 #endif
-    if(!expanded)
-        expanded = strdup(filename);
-    return expanded;
+	if (!expanded)
+		expanded = strdup(filename);
+	return expanded;
 }
 
 DLLIMPORT void cfg_free_value(cfg_opt_t *opt)
 {
-    if(opt == 0)
-        return;
+	if (opt == 0)
+		return;
 
-    if(opt->values)
-    {
-        unsigned int i;
+	if (opt->values) {
+		unsigned int i;
 
-        for(i = 0; i < opt->nvalues; i++)
-        {
-            if(opt->type == CFGT_STR)
-                free(opt->values[i]->string);
-            else if(opt->type == CFGT_SEC) {
-                opt->values[i]->section->path = 0;
-                cfg_free(opt->values[i]->section);
-            }
-            else if(opt->type == CFGT_PTR && opt->freecb && opt->values[i]->ptr)
-                (opt->freecb)(opt->values[i]->ptr);
-            free(opt->values[i]);
-        }
-        free(opt->values);
-    }
-    opt->values = 0;
-    opt->nvalues = 0;
+		for (i = 0; i < opt->nvalues; i++) {
+			if (opt->type == CFGT_STR)
+				free(opt->values[i]->string);
+			else if (opt->type == CFGT_SEC) {
+				opt->values[i]->section->path = 0;
+				cfg_free(opt->values[i]->section);
+			} else if (opt->type == CFGT_PTR && opt->freecb && opt->values[i]->ptr)
+				(opt->freecb) (opt->values[i]->ptr);
+			free(opt->values[i]);
+		}
+		free(opt->values);
+	}
+	opt->values = 0;
+	opt->nvalues = 0;
 }
 
 static void cfg_free_opt_array(cfg_opt_t *opts)
 {
-    int i;
+	int i;
 
-    for(i = 0; opts[i].name; ++i)
-    {
-        free((void *)opts[i].name);
-        if(opts[i].type == CFGT_FUNC || is_set(CFGF_LIST, opts[i].flags))
-            free(opts[i].def.parsed);
-        else if(opts[i].type == CFGT_STR)
-            free((void *)opts[i].def.string);
-        else if(opts[i].type == CFGT_SEC)
-            cfg_free_opt_array(opts[i].subopts);
-    }
-    free(opts);
+	for (i = 0; opts[i].name; ++i) {
+		free((void *)opts[i].name);
+		if (opts[i].type == CFGT_FUNC || is_set(CFGF_LIST, opts[i].flags))
+			free(opts[i].def.parsed);
+		else if (opts[i].type == CFGT_STR)
+			free((void *)opts[i].def.string);
+		else if (opts[i].type == CFGT_SEC)
+			cfg_free_opt_array(opts[i].subopts);
+	}
+	free(opts);
 }
 
-static void cfg_free_searchpath(cfg_searchpath_t* p)
+static void cfg_free_searchpath(cfg_searchpath_t *p)
 {
-  if (p)
-    {
-      cfg_free_searchpath(p->next);
-      free(p->dir);
-      free(p);
-    }
+	if (p) {
+		cfg_free_searchpath(p->next);
+		free(p->dir);
+		free(p);
+	}
 }
 
 DLLIMPORT void cfg_free(cfg_t *cfg)
 {
-    int i;
+	int i;
 
-    if(cfg == 0)
-        return;
+	if (cfg == 0)
+		return;
 
-    for(i = 0; cfg->opts[i].name; ++i)
-        cfg_free_value(&cfg->opts[i]);
+	for (i = 0; cfg->opts[i].name; ++i)
+		cfg_free_value(&cfg->opts[i]);
 
-    cfg_free_opt_array(cfg->opts);
-    cfg_free_searchpath(cfg->path);
+	cfg_free_opt_array(cfg->opts);
+	cfg_free_searchpath(cfg->path);
 
-    free(cfg->name);
-    free(cfg->title);
-    free(cfg->filename);
+	free(cfg->name);
+	free(cfg->title);
+	free(cfg->filename);
 
-    free(cfg);
+	free(cfg);
 }
 
-DLLIMPORT int cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc,
-                          const char **argv)
+DLLIMPORT int cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
 {
-    opt = NULL;
-    if(argc != 1)
-    {
-        cfg_error(cfg, _("wrong number of arguments to cfg_include()"));
-        return 1;
-    }
-    return cfg_lexer_include(cfg, argv[0]);
+	opt = NULL;
+	if (argc != 1) {
+		cfg_error(cfg, _("wrong number of arguments to cfg_include()"));
+		return 1;
+	}
+	return cfg_lexer_include(cfg, argv[0]);
 }
 
 static cfg_value_t *cfg_opt_getval(cfg_opt_t *opt, unsigned int index)
 {
-    cfg_value_t *val = 0;
+	cfg_value_t *val = 0;
 
-    assert(index == 0 || is_set(CFGF_LIST, opt->flags) || is_set(CFGF_MULTI, opt->flags));
+	assert(index == 0 || is_set(CFGF_LIST, opt->flags) || is_set(CFGF_MULTI, opt->flags));
 
-    if(opt->simple_value.ptr)
-        val = (cfg_value_t *)opt->simple_value.ptr;
-    else
-    {
-        if(is_set(CFGF_RESET, opt->flags))
-        {
-            cfg_free_value(opt);
-            opt->flags &= ~CFGF_RESET;
-        }
+	if (opt->simple_value.ptr)
+		val = (cfg_value_t *)opt->simple_value.ptr;
+	else {
+		if (is_set(CFGF_RESET, opt->flags)) {
+			cfg_free_value(opt);
+			opt->flags &= ~CFGF_RESET;
+		}
 
-        if(index >= opt->nvalues)
-            val = cfg_addval(opt);
-        else
-            val = opt->values[index];
-    }
-    return val;
+		if (index >= opt->nvalues)
+			val = cfg_addval(opt);
+		else
+			val = opt->values[index];
+	}
+	return val;
 }
 
-DLLIMPORT void cfg_opt_setnint(cfg_opt_t *opt, long int value,
-                               unsigned int index)
+DLLIMPORT void cfg_opt_setnint(cfg_opt_t *opt, long int value, unsigned int index)
 {
-    cfg_value_t *val;
-    assert(opt && opt->type == CFGT_INT);
-    val = cfg_opt_getval(opt, index);
-    val->number = value;
+	cfg_value_t *val;
+
+	assert(opt && opt->type == CFGT_INT);
+	val = cfg_opt_getval(opt, index);
+	val->number = value;
 }
 
-DLLIMPORT void cfg_setnint(cfg_t *cfg, const char *name,
-                     long int value, unsigned int index)
+DLLIMPORT void cfg_setnint(cfg_t *cfg, const char *name, long int value, unsigned int index)
 {
-    cfg_opt_setnint(cfg_getopt(cfg, name), value, index);
+	cfg_opt_setnint(cfg_getopt(cfg, name), value, index);
 }
 
 DLLIMPORT void cfg_setint(cfg_t *cfg, const char *name, long int value)
 {
-    cfg_setnint(cfg, name, value, 0);
+	cfg_setnint(cfg, name, value, 0);
 }
 
-DLLIMPORT void cfg_opt_setnfloat(cfg_opt_t *opt, double value,
-                                 unsigned int index)
+DLLIMPORT void cfg_opt_setnfloat(cfg_opt_t *opt, double value, unsigned int index)
 {
-    cfg_value_t *val;
-    assert(opt && opt->type == CFGT_FLOAT);
-    val = cfg_opt_getval(opt, index);
-    val->fpnumber = value;
+	cfg_value_t *val;
+
+	assert(opt && opt->type == CFGT_FLOAT);
+	val = cfg_opt_getval(opt, index);
+	val->fpnumber = value;
 }
 
-DLLIMPORT void cfg_setnfloat(cfg_t *cfg, const char *name,
-                   double value, unsigned int index)
+DLLIMPORT void cfg_setnfloat(cfg_t *cfg, const char *name, double value, unsigned int index)
 {
-    cfg_opt_setnfloat(cfg_getopt(cfg, name), value, index);
+	cfg_opt_setnfloat(cfg_getopt(cfg, name), value, index);
 }
 
 DLLIMPORT void cfg_setfloat(cfg_t *cfg, const char *name, double value)
 {
-    cfg_setnfloat(cfg, name, value, 0);
+	cfg_setnfloat(cfg, name, value, 0);
 }
 
-DLLIMPORT void cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value,
-                                unsigned int index)
+DLLIMPORT void cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value, unsigned int index)
 {
-    cfg_value_t *val;
-    assert(opt && opt->type == CFGT_BOOL);
-    val = cfg_opt_getval(opt, index);
-    val->boolean = value;
+	cfg_value_t *val;
+
+	assert(opt && opt->type == CFGT_BOOL);
+	val = cfg_opt_getval(opt, index);
+	val->boolean = value;
 }
 
-DLLIMPORT void cfg_setnbool(cfg_t *cfg, const char *name,
-                            cfg_bool_t value, unsigned int index)
+DLLIMPORT void cfg_setnbool(cfg_t *cfg, const char *name, cfg_bool_t value, unsigned int index)
 {
-    cfg_opt_setnbool(cfg_getopt(cfg, name), value, index);
+	cfg_opt_setnbool(cfg_getopt(cfg, name), value, index);
 }
 
 DLLIMPORT void cfg_setbool(cfg_t *cfg, const char *name, cfg_bool_t value)
 {
-    cfg_setnbool(cfg, name, value, 0);
+	cfg_setnbool(cfg, name, value, 0);
 }
 
-DLLIMPORT void cfg_opt_setnstr(cfg_opt_t *opt, const char *value,
-                               unsigned int index)
+DLLIMPORT void cfg_opt_setnstr(cfg_opt_t *opt, const char *value, unsigned int index)
 {
-    cfg_value_t *val;
-    assert(opt && opt->type == CFGT_STR);
-    val = cfg_opt_getval(opt, index);
-    free(val->string);
-    val->string = value ? strdup(value) : 0;
+	cfg_value_t *val;
+
+	assert(opt && opt->type == CFGT_STR);
+	val = cfg_opt_getval(opt, index);
+	free(val->string);
+	val->string = value ? strdup(value) : 0;
 }
 
-DLLIMPORT void cfg_setnstr(cfg_t *cfg, const char *name,
-                           const char *value, unsigned int index)
+DLLIMPORT void cfg_setnstr(cfg_t *cfg, const char *name, const char *value, unsigned int index)
 {
-    cfg_opt_setnstr(cfg_getopt(cfg, name), value, index);
+	cfg_opt_setnstr(cfg_getopt(cfg, name), value, index);
 }
 
 DLLIMPORT void cfg_setstr(cfg_t *cfg, const char *name, const char *value)
 {
-    cfg_setnstr(cfg, name, value, 0);
+	cfg_setnstr(cfg, name, value, 0);
 }
 
-static void cfg_addlist_internal(cfg_opt_t *opt,
-                                 unsigned int nvalues, va_list ap)
+static void cfg_addlist_internal(cfg_opt_t *opt, unsigned int nvalues, va_list ap)
 {
-    unsigned int i;
+	unsigned int i;
 
-    for(i = 0; i < nvalues; i++)
-    {
-        switch(opt->type)
-        {
-            case CFGT_INT:
-                cfg_opt_setnint(opt, va_arg(ap, int), opt->nvalues);
-                break;
-            case CFGT_FLOAT:
-                cfg_opt_setnfloat(opt, va_arg(ap, double),
-                                  opt->nvalues);
-                break;
-            case CFGT_BOOL:
-                cfg_opt_setnbool(opt, va_arg(ap, cfg_bool_t),
-                                 opt->nvalues);
-                break;
-            case CFGT_STR:
-                cfg_opt_setnstr(opt, va_arg(ap, char*), opt->nvalues);
-                break;
-            case CFGT_FUNC:
-            case CFGT_SEC:
-            default:
-                break;
-        }
-    }
+	for (i = 0; i < nvalues; i++) {
+		switch (opt->type) {
+		case CFGT_INT:
+			cfg_opt_setnint(opt, va_arg(ap, int), opt->nvalues);
+
+			break;
+		case CFGT_FLOAT:
+			cfg_opt_setnfloat(opt, va_arg(ap, double), opt->nvalues);
+
+			break;
+		case CFGT_BOOL:
+			cfg_opt_setnbool(opt, va_arg(ap, cfg_bool_t), opt->nvalues);
+
+			break;
+		case CFGT_STR:
+			cfg_opt_setnstr(opt, va_arg(ap, char *), opt->nvalues);
+
+			break;
+		case CFGT_FUNC:
+		case CFGT_SEC:
+		default:
+			break;
+		}
+	}
 }
 
-DLLIMPORT void cfg_setlist(cfg_t *cfg, const char *name,
-                           unsigned int nvalues, ...)
+DLLIMPORT void cfg_setlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...)
 {
-    va_list ap;
-    cfg_opt_t *opt = cfg_getopt(cfg, name);
+	va_list ap;
+	cfg_opt_t *opt = cfg_getopt(cfg, name);
 
-    assert(opt && is_set(CFGF_LIST, opt->flags));
+	assert(opt && is_set(CFGF_LIST, opt->flags));
 
-    cfg_free_value(opt);
-    va_start(ap, nvalues);
-    cfg_addlist_internal(opt, nvalues, ap);
-    va_end(ap);
+	cfg_free_value(opt);
+	va_start(ap, nvalues);
+	cfg_addlist_internal(opt, nvalues, ap);
+	va_end(ap);
 }
 
-DLLIMPORT void cfg_addlist(cfg_t *cfg, const char *name,
-                           unsigned int nvalues, ...)
+DLLIMPORT void cfg_addlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...)
 {
-    va_list ap;
-    cfg_opt_t *opt = cfg_getopt(cfg, name);
+	va_list ap;
+	cfg_opt_t *opt = cfg_getopt(cfg, name);
 
-    assert(opt && is_set(CFGF_LIST, opt->flags));
+	assert(opt && is_set(CFGF_LIST, opt->flags));
 
-    va_start(ap, nvalues);
-    cfg_addlist_internal(opt, nvalues, ap);
-    va_end(ap);
+	va_start(ap, nvalues);
+	cfg_addlist_internal(opt, nvalues, ap);
+	va_end(ap);
 }
 
 DLLIMPORT void cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index)
 {
-    unsigned int n;
-    cfg_value_t *val;
+	unsigned int n;
+	cfg_value_t *val;
 
-    assert(opt && opt->type == CFGT_SEC);
-    n = cfg_opt_size(opt);
-    if (index >= n)
-        return;
-    val = cfg_opt_getval(opt, index);
-    if (index + 1 != n)
-    {
-        /* not removing last, move the tail */
-        memmove(&opt->values[index], &opt->values[index + 1],
-                sizeof(opt->values[index]) * (n - index - 1));
-    }
-    --opt->nvalues;
-    val->section->path = 0;
-    cfg_free(val->section);
-    free(val);
+	assert(opt && opt->type == CFGT_SEC);
+	n = cfg_opt_size(opt);
+	if (index >= n)
+		return;
+	val = cfg_opt_getval(opt, index);
+	if (index + 1 != n) {
+		/* not removing last, move the tail */
+		memmove(&opt->values[index], &opt->values[index + 1], sizeof(opt->values[index]) * (n - index - 1));
+	}
+	--opt->nvalues;
+	val->section->path = 0;
+	cfg_free(val->section);
+	free(val);
 }
 
-DLLIMPORT void cfg_rmnsec(cfg_t *cfg, const char *name,
-                     unsigned int index)
+DLLIMPORT void cfg_rmnsec(cfg_t *cfg, const char *name, unsigned int index)
 {
-    cfg_opt_rmnsec(cfg_getopt(cfg, name), index);
+	cfg_opt_rmnsec(cfg_getopt(cfg, name), index);
 }
 
 DLLIMPORT void cfg_rmsec(cfg_t *cfg, const char *name)
 {
-    cfg_rmnsec(cfg, name, 0);
+	cfg_rmnsec(cfg, name, 0);
 }
 
 DLLIMPORT void cfg_opt_rmtsec(cfg_opt_t *opt, const char *title)
 {
-    unsigned int i, n;
+	unsigned int i, n;
 
-    assert(opt && title);
-    if(!is_set(CFGF_TITLE, opt->flags))
-        return;
-    n = cfg_opt_size(opt);
-    for(i = 0; i < n; i++)
-    {
-        cfg_t *sec = cfg_opt_getnsec(opt, i);
-        assert(sec && sec->title);
-        if(is_set(CFGF_NOCASE, opt->flags))
-        {
-            if(strcasecmp(title, sec->title) == 0)
-                break;
-        }
-        else
-        {
-            if(strcmp(title, sec->title) == 0)
-                break;
-        }
-    }
-    if (i == n)
-        return;
-    cfg_opt_rmnsec(opt, i);
+	assert(opt && title);
+	if (!is_set(CFGF_TITLE, opt->flags))
+		return;
+	n = cfg_opt_size(opt);
+	for (i = 0; i < n; i++) {
+		cfg_t *sec = cfg_opt_getnsec(opt, i);
+
+		assert(sec && sec->title);
+		if (is_set(CFGF_NOCASE, opt->flags)) {
+			if (strcasecmp(title, sec->title) == 0)
+				break;
+		} else {
+			if (strcmp(title, sec->title) == 0)
+				break;
+		}
+	}
+	if (i == n)
+		return;
+	cfg_opt_rmnsec(opt, i);
 }
 
 DLLIMPORT void cfg_rmtsec(cfg_t *cfg, const char *name, const char *title)
 {
-    cfg_opt_rmtsec(cfg_getopt(cfg, name), title);
+	cfg_opt_rmtsec(cfg_getopt(cfg, name), title);
 }
 
 DLLIMPORT void cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index, FILE *fp)
 {
-    const char *str;
+	const char *str;
 
-    assert(opt && fp);
-    switch(opt->type)
-    {
-        case CFGT_INT:
-            fprintf(fp, "%ld", cfg_opt_getnint(opt, index));
-            break;
-        case CFGT_FLOAT:
-            fprintf(fp, "%f", cfg_opt_getnfloat(opt, index));
-            break;
-        case CFGT_STR:
-            str = cfg_opt_getnstr(opt, index);
-            fprintf(fp, "\"");
-            while (str && *str)
-	    {
-                if(*str == '"')
-                    fprintf(fp, "\\\"");
-                else if(*str == '\\')
-                    fprintf(fp, "\\\\");
-                else
-                    fprintf(fp, "%c", *str);
-                str++;
-            }
-            fprintf(fp, "\"");
-            break;
-        case CFGT_BOOL:
-            fprintf(fp, "%s", cfg_opt_getnbool(opt, index) ? "true" : "false");
-            break;
-        case CFGT_NONE:
-        case CFGT_SEC:
-        case CFGT_FUNC:
-        case CFGT_PTR:
-            break;
-    }
+	assert(opt && fp);
+	switch (opt->type) {
+	case CFGT_INT:
+		fprintf(fp, "%ld", cfg_opt_getnint(opt, index));
+		break;
+	case CFGT_FLOAT:
+		fprintf(fp, "%f", cfg_opt_getnfloat(opt, index));
+		break;
+	case CFGT_STR:
+		str = cfg_opt_getnstr(opt, index);
+		fprintf(fp, "\"");
+		while (str && *str) {
+			if (*str == '"')
+				fprintf(fp, "\\\"");
+			else if (*str == '\\')
+				fprintf(fp, "\\\\");
+			else
+				fprintf(fp, "%c", *str);
+			str++;
+		}
+		fprintf(fp, "\"");
+		break;
+	case CFGT_BOOL:
+		fprintf(fp, "%s", cfg_opt_getnbool(opt, index) ? "true" : "false");
+		break;
+	case CFGT_NONE:
+	case CFGT_SEC:
+	case CFGT_FUNC:
+	case CFGT_PTR:
+		break;
+	}
 }
 
 static void cfg_indent(FILE *fp, int indent)
 {
-    while(indent--)
-        fprintf(fp, "  ");
+	while (indent--)
+		fprintf(fp, "  ");
 }
 
 DLLIMPORT void cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent)
 {
-    assert(opt && fp);
+	assert(opt && fp);
 
-    if(opt->type == CFGT_SEC)
-    {
-        cfg_t *sec;
-        unsigned int i;
+	if (opt->type == CFGT_SEC) {
+		cfg_t *sec;
+		unsigned int i;
 
-        for(i = 0; i < cfg_opt_size(opt); i++)
-        {
-            sec = cfg_opt_getnsec(opt, i);
-            cfg_indent(fp, indent);
-            if(is_set(CFGF_TITLE, opt->flags))
-                fprintf(fp, "%s \"%s\" {\n", opt->name, cfg_title(sec));
-            else
-                fprintf(fp, "%s {\n", opt->name);
-            cfg_print_indent(sec, fp, indent + 1);
-            cfg_indent(fp, indent);
-            fprintf(fp, "}\n");
-        }
-    }
-    else if(opt->type != CFGT_FUNC && opt->type != CFGT_NONE)
-    {
-        if(is_set(CFGF_LIST, opt->flags))
-        {
-            cfg_indent(fp, indent);
-            fprintf(fp, "%s = {", opt->name);
+		for (i = 0; i < cfg_opt_size(opt); i++) {
+			sec = cfg_opt_getnsec(opt, i);
+			cfg_indent(fp, indent);
+			if (is_set(CFGF_TITLE, opt->flags))
+				fprintf(fp, "%s \"%s\" {\n", opt->name, cfg_title(sec));
+			else
+				fprintf(fp, "%s {\n", opt->name);
+			cfg_print_indent(sec, fp, indent + 1);
+			cfg_indent(fp, indent);
+			fprintf(fp, "}\n");
+		}
+	} else if (opt->type != CFGT_FUNC && opt->type != CFGT_NONE) {
+		if (is_set(CFGF_LIST, opt->flags)) {
+			cfg_indent(fp, indent);
+			fprintf(fp, "%s = {", opt->name);
 
-            if(opt->nvalues)
-            {
-                unsigned int i;
+			if (opt->nvalues) {
+				unsigned int i;
 
-                if(opt->pf)
-                    opt->pf(opt, 0, fp);
-                else
-                    cfg_opt_nprint_var(opt, 0, fp);
-                for(i = 1; i < opt->nvalues; i++)
-                {
-                    fprintf(fp, ", ");
-                    if(opt->pf)
-                        opt->pf(opt, i, fp);
-                    else
-                        cfg_opt_nprint_var(opt, i, fp);
-                }
-            }
+				if (opt->pf)
+					opt->pf(opt, 0, fp);
+				else
+					cfg_opt_nprint_var(opt, 0, fp);
+				for (i = 1; i < opt->nvalues; i++) {
+					fprintf(fp, ", ");
+					if (opt->pf)
+						opt->pf(opt, i, fp);
+					else
+						cfg_opt_nprint_var(opt, i, fp);
+				}
+			}
 
-            fprintf(fp, "}");
-        }
-        else
-        {
-            cfg_indent(fp, indent);
-            /* comment out the option if is not set */
-            if(opt->simple_value.ptr)
-            {
-                if(opt->type == CFGT_STR && *opt->simple_value.string == 0)
-                    fprintf(fp, "# ");
-            }
-            else
-            {
-                if(cfg_opt_size(opt) == 0 || (
-                       opt->type == CFGT_STR && (opt->values[0]->string == 0 ||
-                                             opt->values[0]->string[0] == 0)))
-                    fprintf(fp, "# ");
-            }
-            fprintf(fp, "%s=", opt->name);
-            if(opt->pf)
-                opt->pf(opt, 0, fp);
-            else
-                cfg_opt_nprint_var(opt, 0, fp);
-        }
-    
-        fprintf(fp, "\n");
-    }
-    else if(opt->pf)
-    {
-        cfg_indent(fp, indent);
-        opt->pf(opt, 0, fp);
-        fprintf(fp, "\n");
-    }
+			fprintf(fp, "}");
+		} else {
+			cfg_indent(fp, indent);
+			/* comment out the option if is not set */
+			if (opt->simple_value.ptr) {
+				if (opt->type == CFGT_STR && *opt->simple_value.string == 0)
+					fprintf(fp, "# ");
+			} else {
+				if (cfg_opt_size(opt) == 0 || (opt->type == CFGT_STR && (opt->values[0]->string == 0 ||
+											 opt->values[0]->string[0] == 0)))
+					fprintf(fp, "# ");
+			}
+			fprintf(fp, "%s=", opt->name);
+			if (opt->pf)
+				opt->pf(opt, 0, fp);
+			else
+				cfg_opt_nprint_var(opt, 0, fp);
+		}
+
+		fprintf(fp, "\n");
+	} else if (opt->pf) {
+		cfg_indent(fp, indent);
+		opt->pf(opt, 0, fp);
+		fprintf(fp, "\n");
+	}
 }
 
 DLLIMPORT void cfg_opt_print(cfg_opt_t *opt, FILE *fp)
 {
-    cfg_opt_print_indent(opt, fp, 0);
+	cfg_opt_print_indent(opt, fp, 0);
 }
 
 DLLIMPORT void cfg_print_indent(cfg_t *cfg, FILE *fp, int indent)
 {
-    int i;
+	int i;
 
-    for(i = 0; cfg->opts[i].name; i++)
-        cfg_opt_print_indent(&cfg->opts[i], fp, indent);
+	for (i = 0; cfg->opts[i].name; i++)
+		cfg_opt_print_indent(&cfg->opts[i], fp, indent);
 }
 
 DLLIMPORT void cfg_print(cfg_t *cfg, FILE *fp)
 {
-    cfg_print_indent(cfg, fp, 0);
+	cfg_print_indent(cfg, fp, 0);
 }
 
-DLLIMPORT cfg_print_func_t cfg_opt_set_print_func(cfg_opt_t *opt,
-                                                  cfg_print_func_t pf)
+DLLIMPORT cfg_print_func_t cfg_opt_set_print_func(cfg_opt_t *opt, cfg_print_func_t pf)
 {
-    cfg_print_func_t oldpf;
+	cfg_print_func_t oldpf;
 
-    assert(opt);
-    oldpf = opt->pf;
-    opt->pf = pf;
+	assert(opt);
+	oldpf = opt->pf;
+	opt->pf = pf;
 
-    return oldpf;
+	return oldpf;
 }
 
-DLLIMPORT cfg_print_func_t cfg_set_print_func(cfg_t *cfg, const char *name,
-                                              cfg_print_func_t pf)
+DLLIMPORT cfg_print_func_t cfg_set_print_func(cfg_t *cfg, const char *name, cfg_print_func_t pf)
 {
-    return cfg_opt_set_print_func(cfg_getopt(cfg, name), pf);
+	return cfg_opt_set_print_func(cfg_getopt(cfg, name), pf);
 }
 
 static cfg_opt_t *cfg_getopt_array(cfg_opt_t *rootopts, int cfg_flags, const char *name)
 {
-    unsigned int i;
-    cfg_opt_t *opts = rootopts;
+	unsigned int i;
+	cfg_opt_t *opts = rootopts;
 
-    assert(rootopts && name);
+	assert(rootopts && name);
 
-    while(name && *name)
-    {
-        cfg_t *seccfg;
-        char *secname;
-        size_t len = strcspn(name, "|");
-        if(name[len] == 0 /*len == strlen(name)*/)
-            /* no more subsections */
-            break;
-        if(len)
-        {
-            cfg_opt_t *secopt;
-            secname = strndup(name, len);
-            secopt = cfg_getopt_array(opts, cfg_flags, secname);
-            free(secname);
-            if(secopt == 0)
-            {
-                /*fprintf(stderr, "section not found\n");*/
-                return 0;
-            }
-            if(secopt->type != CFGT_SEC)
-            {
-                /*fprintf(stderr, "not a section!\n");*/
-                return 0;
-            }
+	while (name && *name) {
+		cfg_t *seccfg;
+		char *secname;
+		size_t len = strcspn(name, "|");
 
-            if(!is_set(CFGF_MULTI, secopt->flags) &&
-	       (seccfg = cfg_opt_getnsec(secopt, 0)) != 0)
-	    {
-                opts = seccfg->opts;
-	    }
-            else
-                opts = secopt->subopts;
-            if(opts == 0)
-            {
-                /*fprintf(stderr, "section have no subopts!?\n");*/
-                return 0;
-            }
-        }
-        name += len;
-        name += strspn(name, "|");
-    }
+		if (name[len] == 0 /*len == strlen(name) */ )
+			/* no more subsections */
+			break;
+		if (len) {
+			cfg_opt_t *secopt;
 
-    for(i = 0; opts[i].name; i++)
-    {
-        if(is_set(CFGF_NOCASE, cfg_flags))
-        {
-            if(strcasecmp(opts[i].name, name) == 0)
-                return &opts[i];
-        }
-        else
-        {
-            if(strcmp(opts[i].name, name) == 0)
-                return &opts[i];
-        }
-    }
-    return 0;
+			secname = strndup(name, len);
+			secopt = cfg_getopt_array(opts, cfg_flags, secname);
+			free(secname);
+			if (secopt == 0) {
+				/*fprintf(stderr, "section not found\n"); */
+				return 0;
+			}
+			if (secopt->type != CFGT_SEC) {
+				/*fprintf(stderr, "not a section!\n"); */
+				return 0;
+			}
+
+			if (!is_set(CFGF_MULTI, secopt->flags) && (seccfg = cfg_opt_getnsec(secopt, 0)) != 0) {
+				opts = seccfg->opts;
+			} else
+				opts = secopt->subopts;
+			if (opts == 0) {
+				/*fprintf(stderr, "section have no subopts!?\n"); */
+				return 0;
+			}
+		}
+		name += len;
+		name += strspn(name, "|");
+	}
+
+	for (i = 0; opts[i].name; i++) {
+		if (is_set(CFGF_NOCASE, cfg_flags)) {
+			if (strcasecmp(opts[i].name, name) == 0)
+				return &opts[i];
+		} else {
+			if (strcmp(opts[i].name, name) == 0)
+				return &opts[i];
+		}
+	}
+	return 0;
 }
 
-DLLIMPORT cfg_validate_callback_t cfg_set_validate_func(cfg_t *cfg,
-                                                        const char *name,
-                                                        cfg_validate_callback_t vf)
+DLLIMPORT cfg_validate_callback_t cfg_set_validate_func(cfg_t *cfg, const char *name, cfg_validate_callback_t vf)
 {
-    cfg_opt_t *opt = cfg_getopt_array(cfg->opts, cfg->flags, name);
-    cfg_validate_callback_t oldvf;
-    assert(opt);
-    oldvf = opt->validcb;
-    opt->validcb = vf;
-    return oldvf;
+	cfg_opt_t *opt = cfg_getopt_array(cfg->opts, cfg->flags, name);
+	cfg_validate_callback_t oldvf;
+
+	assert(opt);
+	oldvf = opt->validcb;
+	opt->validcb = vf;
+	return oldvf;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -33,8 +33,8 @@
  * <em>If you can't convince, confuse.</em>
  */
 
-#ifndef _cfg_h_
-#define _cfg_h_
+#ifndef CONFUSE_H_
+#define CONFUSE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,14 +66,14 @@ extern "C" {
 
 /** Fundamental option types */
 enum cfg_type_t {
-    CFGT_NONE,
-    CFGT_INT,     /**< integer */
-    CFGT_FLOAT,   /**< floating point number */
-    CFGT_STR,     /**< string */
-    CFGT_BOOL,    /**< boolean value */
-    CFGT_SEC,     /**< section */
-    CFGT_FUNC,    /**< function */
-    CFGT_PTR      /**< pointer to user-defined value */
+	CFGT_NONE,
+	CFGT_INT,    /**< integer */
+	CFGT_FLOAT,  /**< floating point number */
+	CFGT_STR,    /**< string */
+	CFGT_BOOL,   /**< boolean value */
+	CFGT_SEC,    /**< section */
+	CFGT_FUNC,   /**< function */
+	CFGT_PTR     /**< pointer to user-defined value */
 };
 typedef enum cfg_type_t cfg_type_t;
 
@@ -130,8 +130,7 @@ typedef struct cfg_searchpath_t cfg_searchpath_t;
  *
  * @see CFG_FUNC
  */
-typedef int (*cfg_func_t)(cfg_t *cfg, cfg_opt_t *opt,
-                          int argc, const char **argv);
+typedef int (*cfg_func_t)(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv);
 
 /** Function prototype used by the cfg_print_ functions.
  *
@@ -154,7 +153,7 @@ typedef int (*cfg_func_t)(cfg_t *cfg, cfg_opt_t *opt,
  * @see cfg_print, cfg_set_print_func
  */
 typedef void (*cfg_print_func_t)(cfg_opt_t *opt, unsigned int index, FILE *fp);
-    
+
 /** Value parsing callback prototype
  *
  * This is a callback function (different from the one registered with the
@@ -176,8 +175,7 @@ typedef void (*cfg_print_func_t)(cfg_opt_t *opt, unsigned int index, FILE *fp);
  * error, and the parsing is aborted. The callback function should notify the
  * error itself, for example by calling cfg_error().
  */
-typedef int (*cfg_callback_t)(cfg_t *cfg, cfg_opt_t *opt,
-                              const char *value, void *result);
+typedef int (*cfg_callback_t)(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result);
 
 /** Validating callback prototype
  *
@@ -205,7 +203,7 @@ typedef int (*cfg_validate_callback_t)(cfg_t *cfg, cfg_opt_t *opt);
 typedef void (*cfg_free_func_t)(void *value);
 
 /** Boolean values. */
-typedef enum {cfg_false, cfg_true} cfg_bool_t;
+typedef enum { cfg_false, cfg_true } cfg_bool_t;
 
 /** Error reporting function. */
 typedef void (*cfg_errfunc_t)(cfg_t *cfg, const char *fmt, va_list ap);
@@ -215,54 +213,54 @@ typedef void (*cfg_errfunc_t)(cfg_t *cfg, const char *fmt, va_list ap);
  * booleans or other sections) grouped together.
  */
 struct cfg_t {
-    cfg_flag_t flags;       /**< Any flags passed to cfg_init() */
-    char *name;             /**< The name of this section, the root
-                             * section returned from cfg_init() is
-                             * always named "root" */
-    cfg_opt_t *opts;        /**< Array of options */
-    char *title;            /**< Optional title for this section, only
-                             * set if CFGF_TITLE flag is set */
-    char *filename;         /**< Name of the file being parsed */
-    int line;               /**< Line number in the config file */
-    cfg_errfunc_t errfunc;  /**< This function (if set with
-                             * cfg_set_error_function) is called for
-                             * any error message. */
-    cfg_searchpath_t *path; /**< Linked list of directories to search */ 
+	cfg_flag_t flags;	/**< Any flags passed to cfg_init() */
+	char *name;		/**< The name of this section, the root
+				 * section returned from cfg_init() is
+				 * always named "root" */
+	cfg_opt_t *opts;        /**< Array of options */
+	char *title;	        /**< Optional title for this section, only
+				 * set if CFGF_TITLE flag is set */
+	char *filename;		/**< Name of the file being parsed */
+	int line;		/**< Line number in the config file */
+	cfg_errfunc_t errfunc;	/**< This function (if set with
+				 * cfg_set_error_function) is called for
+				 * any error message. */
+	cfg_searchpath_t *path;	/**< Linked list of directories to search */
 };
 
 /** Data structure holding the value of a fundamental option value.
  */
 union cfg_value_t {
-    long int number;        /**< integer value */
-    double fpnumber;        /**< floating point value */
-    cfg_bool_t boolean;     /**< boolean value */
-    char *string;           /**< string value */
-    cfg_t *section;         /**< section value */
-    void *ptr;              /**< user-defined value */
+	long int number;	/**< integer value */
+	double fpnumber;	/**< floating point value */
+	cfg_bool_t boolean;	/**< boolean value */
+	char *string;		/**< string value */
+	cfg_t *section;		/**< section value */
+	void *ptr;		/**< user-defined value */
 };
 
 /** Data structure holding the pointer to a user provided variable
  *  defined with CFG_SIMPLE_*
  */
 union cfg_simple_t {
-    long int *number;
-    double *fpnumber;
-    cfg_bool_t *boolean;
-    char **string;
-    void **ptr;
+	long int *number;
+	double *fpnumber;
+	cfg_bool_t *boolean;
+	char **string;
+	void **ptr;
 };
 
 /** Data structure holding the default value given by the
  *  initialization macros.
  */
 struct cfg_defvalue_t {
-    long int number;        /**< default integer value */
-    double fpnumber;        /**< default floating point value */
-    cfg_bool_t boolean;     /**< default boolean value */
-    const char *string;     /**< default string value */
-    char *parsed;           /**< default value that is parsed by
-                             * libConfuse, used for lists and
-                             * functions */
+	long int number; 	/**< default integer value */
+	double fpnumber;	/**< default floating point value */
+	cfg_bool_t boolean;	/**< default boolean value */
+	const char *string;	/**< default string value */
+	char *parsed;		/**< default value that is parsed by
+				 * libConfuse, used for lists and
+				 * functions */
 };
 
 /** Data structure holding information about an option. The value(s)
@@ -270,21 +268,21 @@ struct cfg_defvalue_t {
  * etc).
  */
 struct cfg_opt_t {
-    const char *name;       /**< The name of the option */
-    cfg_type_t type;        /**< Type of option */
-    unsigned int nvalues;   /**< Number of values parsed */
-    cfg_value_t **values;   /**< Array of found values */
-    cfg_flag_t flags;       /**< Flags */
-    cfg_opt_t *subopts;     /**< Suboptions (only applies to sections) */
-    cfg_defvalue_t def;     /**< Default value */
-    cfg_func_t func;        /**< Function callback for CFGT_FUNC options */
-    cfg_simple_t simple_value;     /**< Pointer to user-specified variable to
-                             * store simple values (created with the
-                             * CFG_SIMPLE_* initializers) */
-    cfg_callback_t parsecb; /**< Value parsing callback function */
-    cfg_validate_callback_t validcb; /**< Value validating callback function */
-    cfg_print_func_t pf;    /**< print callback function */
-    cfg_free_func_t freecb; /***< user-defined memory release function */
+	const char *name;	/**< The name of the option */
+	cfg_type_t type;	/**< Type of option */
+	unsigned int nvalues;	/**< Number of values parsed */
+	cfg_value_t **values;	/**< Array of found values */
+	cfg_flag_t flags;	/**< Flags */
+	cfg_opt_t *subopts;	/**< Suboptions (only applies to sections) */
+	cfg_defvalue_t def;	/**< Default value */
+	cfg_func_t func;	/**< Function callback for CFGT_FUNC options */
+	cfg_simple_t simple_value;	/**< Pointer to user-specified variable to
+					 * store simple values (created with the
+					 * CFG_SIMPLE_* initializers) */
+	cfg_callback_t parsecb;	/**< Value parsing callback function */
+	cfg_validate_callback_t validcb;/**< Value validating callback function */
+	cfg_print_func_t pf;	/**< print callback function */
+	cfg_free_func_t freecb;	/***< user-defined memory release function */
 };
 
 extern const char __export confuse_copyright[];
@@ -533,7 +531,7 @@ extern const char __export confuse_author[];
  * the option list.
  */
 #define CFG_END() \
-   {0,CFGT_NONE,0,0,CFGF_NONE,0,{0,0,cfg_false,0,0},0,{0},0,0,0,0}
+  {0,CFGT_NONE,0,0,CFGF_NONE,0,{0,0,cfg_false,0,0},0,{0},0,0,0,0}
 
 
 
@@ -558,7 +556,7 @@ extern const char __export confuse_author[];
  * @return A configuration context structure. This pointer is passed
  * to almost all other functions as the first parameter.
  */
-DLLIMPORT cfg_t * __export cfg_init(cfg_opt_t *opts, cfg_flag_t flags);
+DLLIMPORT cfg_t *__export cfg_init(cfg_opt_t *opts, cfg_flag_t flags);
 
 /** Add a searchpath directory to the configuration context, the 
  * const char* argument will be duplicated and then freed as part 
@@ -589,8 +587,7 @@ DLLIMPORT int __export cfg_add_searchpath(cfg_t *cfg, const char *dir);
  * @return If the file is found on the searchpath then the full
  * path to the file is returned. If not found, NULL is returned.  
  */
-DLLIMPORT char *__export cfg_searchpath(cfg_searchpath_t* path, 
-					const char *file);
+DLLIMPORT char *__export cfg_searchpath(cfg_searchpath_t *path, const char *file);
 
 /** Parse a configuration file. Tilde expansion is performed on the
  * filename before it is opened. After a configuration file has been
@@ -644,8 +641,7 @@ DLLIMPORT void __export cfg_free(cfg_t *cfg);
 /** Install a user-defined error reporting function.
  * @return The old error reporting function is returned.
  */
-DLLIMPORT cfg_errfunc_t __export cfg_set_error_function(cfg_t *cfg,
-                                                        cfg_errfunc_t errfunc);
+DLLIMPORT cfg_errfunc_t __export cfg_set_error_function(cfg_t *cfg, cfg_errfunc_t errfunc);
 
 /** Show a parser error. Any user-defined error reporting function is called.
  * @see cfg_set_error_function
@@ -665,8 +661,7 @@ DLLIMPORT signed long __export cfg_opt_getnint(cfg_opt_t *opt, unsigned int inde
  * @param index Index of the value to get. Zero based.
  * @see cfg_getint
  */
-DLLIMPORT long int __export cfg_getnint(cfg_t *cfg, const char *name,
-                                        unsigned int index);
+DLLIMPORT long int __export cfg_getnint(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Returns the value of an integer option. This is the same as
  * calling cfg_getnint with index 0.
@@ -692,8 +687,7 @@ DLLIMPORT double __export cfg_opt_getnfloat(cfg_opt_t *opt, unsigned int index);
  * @param index Index of the value to get. Zero based.
  * @see cfg_getfloat
  */
-DLLIMPORT double __export cfg_getnfloat(cfg_t *cfg, const char *name,
-                                        unsigned int index);
+DLLIMPORT double __export cfg_getnfloat(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Returns the value of a floating point option.
  * @param cfg The configuration file context.
@@ -710,7 +704,7 @@ DLLIMPORT double __export cfg_getfloat(cfg_t *cfg, const char *name);
  * @param index Index of the value to get. Zero based.
  * @see cfg_getnstr
  */
-DLLIMPORT char * __export cfg_opt_getnstr(cfg_opt_t *opt, unsigned int index);
+DLLIMPORT char *__export cfg_opt_getnstr(cfg_opt_t *opt, unsigned int index);
 
 /** Indexed version of cfg_getstr(), used for lists.
  * @param cfg The configuration file context.
@@ -718,8 +712,7 @@ DLLIMPORT char * __export cfg_opt_getnstr(cfg_opt_t *opt, unsigned int index);
  * @param index Index of the value to get. Zero based.
  * @see cfg_getstr
  */
-DLLIMPORT char * __export cfg_getnstr(cfg_t *cfg, const char *name,
-                                      unsigned int index);
+DLLIMPORT char *__export cfg_getnstr(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Returns the value of a string option.
  * @param cfg The configuration file context.
@@ -729,7 +722,7 @@ DLLIMPORT char * __export cfg_getnstr(cfg_t *cfg, const char *name,
  * corresponding cfg_opt_t structure is returned. It is an error to
  * try to get an option that isn't declared.
  */
-DLLIMPORT char * __export cfg_getstr(cfg_t *cfg, const char *name);
+DLLIMPORT char *__export cfg_getstr(cfg_t *cfg, const char *name);
 
 /** Returns the value of a boolean option, given a cfg_opt_t pointer.
  * @param opt The option structure (eg, as returned from cfg_getopt())
@@ -737,7 +730,7 @@ DLLIMPORT char * __export cfg_getstr(cfg_t *cfg, const char *name);
  * @see cfg_getnbool
  */
 DLLIMPORT cfg_bool_t __export cfg_opt_getnbool(cfg_opt_t *opt, unsigned int index);
-    
+
 /** Indexed version of cfg_getbool(), used for lists.
  *
  * @param cfg The configuration file context.
@@ -745,8 +738,7 @@ DLLIMPORT cfg_bool_t __export cfg_opt_getnbool(cfg_opt_t *opt, unsigned int inde
  * @param index Index of the value to get. Zero based.
  * @see cfg_getbool
  */
-DLLIMPORT cfg_bool_t __export cfg_getnbool(cfg_t *cfg, const char *name,
-                                           unsigned int index);
+DLLIMPORT cfg_bool_t __export cfg_getnbool(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Returns the value of a boolean option.
  * @param cfg The configuration file context.
@@ -759,8 +751,8 @@ DLLIMPORT cfg_bool_t __export cfg_getnbool(cfg_t *cfg, const char *name,
 DLLIMPORT cfg_bool_t __export cfg_getbool(cfg_t *cfg, const char *name);
 
 
-DLLIMPORT void * __export cfg_opt_getnptr(cfg_opt_t *opt, unsigned int index);
-DLLIMPORT void * __export cfg_getnptr(cfg_t *cfg, const char *name, unsigned int indx);
+DLLIMPORT void *__export cfg_opt_getnptr(cfg_opt_t *opt, unsigned int index);
+DLLIMPORT void *__export cfg_getnptr(cfg_t *cfg, const char *name, unsigned int indx);
 
 /** Returns the value of a user-defined option (void pointer).
  * @param cfg The configuration file context.
@@ -770,7 +762,7 @@ DLLIMPORT void * __export cfg_getnptr(cfg_t *cfg, const char *name, unsigned int
  * corresponding cfg_opt_t structure is returned. It is an error to
  * try to get an option that isn't declared.
  */
-DLLIMPORT void * __export cfg_getptr(cfg_t *cfg, const char *name);
+DLLIMPORT void *__export cfg_getptr(cfg_t *cfg, const char *name);
 
 
 /** Returns the value of a section option, given a cfg_opt_t pointer.
@@ -778,7 +770,7 @@ DLLIMPORT void * __export cfg_getptr(cfg_t *cfg, const char *name);
  * @param index Index of the value to get. Zero based.
  * @see cfg_getnsec
  */
-DLLIMPORT cfg_t * __export cfg_opt_getnsec(cfg_opt_t *opt, unsigned int index);
+DLLIMPORT cfg_t *__export cfg_opt_getnsec(cfg_opt_t *opt, unsigned int index);
 
 /** Indexed version of cfg_getsec(), used for sections with the
  * CFGF_MULTI flag set.
@@ -788,8 +780,7 @@ DLLIMPORT cfg_t * __export cfg_opt_getnsec(cfg_opt_t *opt, unsigned int index);
  * @param index Index of the section to get. Zero based.
  * @see cfg_getsec
  */
-DLLIMPORT cfg_t * __export cfg_getnsec(cfg_t *cfg, const char *name,
-                                       unsigned int index);
+DLLIMPORT cfg_t *__export cfg_getnsec(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Returns the value of a section option, given a cfg_opt_t pointer
  * and the title.
@@ -798,7 +789,7 @@ DLLIMPORT cfg_t * __export cfg_getnsec(cfg_t *cfg, const char *name,
  * have been set for this option.
  * @see cfg_gettsec
  */
-DLLIMPORT cfg_t * __export cfg_opt_gettsec(cfg_opt_t *opt, const char *title);
+DLLIMPORT cfg_t *__export cfg_opt_gettsec(cfg_opt_t *opt, const char *title);
 
 /** Return a section given the title, used for section with the
  * CFGF_TITLE flag set.
@@ -809,8 +800,7 @@ DLLIMPORT cfg_t * __export cfg_opt_gettsec(cfg_opt_t *opt, const char *title);
  * have been set for this option.
  * @see cfg_getsec
  */
-DLLIMPORT cfg_t * __export cfg_gettsec(cfg_t *cfg, const char *name,
-                                       const char *title);
+DLLIMPORT cfg_t *__export cfg_gettsec(cfg_t *cfg, const char *name, const char *title);
 
 /** Returns the value of a section option. The returned value is
  * another cfg_t structure that can be used in following calls to
@@ -822,7 +812,7 @@ DLLIMPORT cfg_t * __export cfg_gettsec(cfg_t *cfg, const char *name,
  * section without the CFGF_MULTI flag set. It is an error to try to
  * get a section that isn't declared.
  */
-DLLIMPORT cfg_t * __export cfg_getsec(cfg_t *cfg, const char *name);
+DLLIMPORT cfg_t *__export cfg_getsec(cfg_t *cfg, const char *name);
 
 /** Return the number of values this option has. If no default value
  * is given for the option and no value was found in the config file,
@@ -851,7 +841,7 @@ DLLIMPORT unsigned int __export cfg_size(cfg_t *cfg, const char *name);
  * @return Returns the title, or 0 if there is no title. This string
  * should not be modified.
  */
-DLLIMPORT const char * __export cfg_title(cfg_t *cfg);
+DLLIMPORT const char *__export cfg_title(cfg_t *cfg);
 
 /** Return the name of a section.
  *
@@ -859,7 +849,7 @@ DLLIMPORT const char * __export cfg_title(cfg_t *cfg);
  * @return Returns the title, or 0 if there is no title. This string
  * should not be modified.
  */
-DLLIMPORT const char * __export cfg_name(cfg_t *cfg);
+DLLIMPORT const char *__export cfg_name(cfg_t *cfg);
 
 /** Return the name of an option.
  *
@@ -867,15 +857,14 @@ DLLIMPORT const char * __export cfg_name(cfg_t *cfg);
  * @return Returns the title, or 0 if there is no title. This string
  * should not be modified.
  */
-DLLIMPORT const char * __export cfg_opt_name(cfg_opt_t *opt);
+DLLIMPORT const char *__export cfg_opt_name(cfg_opt_t *opt);
 
 /** Predefined include-function. This function can be used in the
  * options passed to cfg_init() to specify a function for including
  * other configuration files in the parsing. For example:
  * CFG_FUNC("include", &cfg_include)
  */
-DLLIMPORT int __export cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc,
-                                   const char **argv);
+DLLIMPORT int __export cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv);
 
 /** Does tilde expansion (~ -> $HOME) on the filename.
  * @return The expanded filename is returned. If a ~user was not
@@ -883,7 +872,7 @@ DLLIMPORT int __export cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc,
  * dynamically allocated string is returned, which should be free()'d
  * by the caller.
  */
-DLLIMPORT char * __export cfg_tilde_expand(const char *filename);
+DLLIMPORT char *__export cfg_tilde_expand(const char *filename);
 
 /** Parse a boolean option string. Accepted "true" values are "true",
  * "on" and "yes", and accepted "false" values are "false", "off" and
@@ -902,7 +891,7 @@ DLLIMPORT int __export cfg_parse_boolean(const char *s);
  * @return Returns a pointer to the option. If the option isn't declared,
  * libConfuse will print an error message and return 0.
  */
-DLLIMPORT cfg_opt_t * __export cfg_getopt(cfg_t *cfg, const char *name);
+DLLIMPORT cfg_opt_t *__export cfg_getopt(cfg_t *cfg, const char *name);
 
 /** Set an option (create an instance of an option).
  *
@@ -922,8 +911,7 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_opt_setnint(cfg_opt_t *opt,
-                                        long int value, unsigned int index);
+DLLIMPORT void __export cfg_opt_setnint(cfg_opt_t *opt, long int value, unsigned int index);
 
 /** Set the value of an integer option given its name.
  *
@@ -932,8 +920,7 @@ DLLIMPORT void __export cfg_opt_setnint(cfg_opt_t *opt,
  * @param value The value to set. If the option is a list (the CFGF_LIST flag
  * is set), only the first value (with index 0) is set.
  */
-DLLIMPORT void __export cfg_setint(cfg_t *cfg, const char *name,
-                                   long int value);
+DLLIMPORT void __export cfg_setint(cfg_t *cfg, const char *name, long int value);
 
 /** Set a value of an integer option given its name and index.
  *
@@ -944,8 +931,7 @@ DLLIMPORT void __export cfg_setint(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_setnint(cfg_t *cfg, const char *name,
-                                    long int value, unsigned int index);
+DLLIMPORT void __export cfg_setnint(cfg_t *cfg, const char *name, long int value, unsigned int index);
 
 /** Set a value of a floating point option.
  *
@@ -955,8 +941,7 @@ DLLIMPORT void __export cfg_setnint(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_opt_setnfloat(cfg_opt_t *opt,
-                                          double value, unsigned int index);
+DLLIMPORT void __export cfg_opt_setnfloat(cfg_opt_t *opt, double value, unsigned int index);
 
 /** Set the value of a floating point option given its name.
  *
@@ -965,8 +950,7 @@ DLLIMPORT void __export cfg_opt_setnfloat(cfg_opt_t *opt,
  * @param value The value to set. If the option is a list (the CFGF_LIST flag
  * is set), only the first value (with index 0) is set.
  */
-DLLIMPORT void __export cfg_setfloat(cfg_t *cfg, const char *name,
-                                     double value);
+DLLIMPORT void __export cfg_setfloat(cfg_t *cfg, const char *name, double value);
 
 /** Set a value of a floating point option given its name and index.
  *
@@ -977,8 +961,7 @@ DLLIMPORT void __export cfg_setfloat(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_setnfloat(cfg_t *cfg, const char *name,
-                                      double value, unsigned int index);
+DLLIMPORT void __export cfg_setnfloat(cfg_t *cfg, const char *name, double value, unsigned int index);
 
 /** Set a value of a boolean option.
  *
@@ -988,8 +971,7 @@ DLLIMPORT void __export cfg_setnfloat(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_opt_setnbool(cfg_opt_t *opt,
-                                         cfg_bool_t value, unsigned int index);
+DLLIMPORT void __export cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value, unsigned int index);
 
 /** Set the value of a boolean option given its name.
  *
@@ -998,8 +980,7 @@ DLLIMPORT void __export cfg_opt_setnbool(cfg_opt_t *opt,
  * @param value The value to set. If the option is a list (the CFGF_LIST flag
  * is set), only the first value (with index 0) is set.
  */
-DLLIMPORT void __export cfg_setbool(cfg_t *cfg, const char *name,
-                                    cfg_bool_t value);
+DLLIMPORT void __export cfg_setbool(cfg_t *cfg, const char *name, cfg_bool_t value);
 
 /** Set a value of a boolean option given its name and index.
  *
@@ -1010,8 +991,7 @@ DLLIMPORT void __export cfg_setbool(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_setnbool(cfg_t *cfg, const char *name,
-                                     cfg_bool_t value, unsigned int index);
+DLLIMPORT void __export cfg_setnbool(cfg_t *cfg, const char *name, cfg_bool_t value, unsigned int index);
 
 /** Set a value of a string option.
  *
@@ -1022,8 +1002,7 @@ DLLIMPORT void __export cfg_setnbool(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_opt_setnstr(cfg_opt_t *opt,
-                                        const char *value, unsigned int index);
+DLLIMPORT void __export cfg_opt_setnstr(cfg_opt_t *opt, const char *value, unsigned int index);
 
 /** Set the value of a string option given its name.
  *
@@ -1033,8 +1012,7 @@ DLLIMPORT void __export cfg_opt_setnstr(cfg_opt_t *opt,
  * value is copied. Any previous string value is freed. If the option is a list
  * (the CFGF_LIST flag is set), only the first value (with index 0) is set.
  */
-DLLIMPORT void __export cfg_setstr(cfg_t *cfg, const char *name,
-                                   const char *value);
+DLLIMPORT void __export cfg_setstr(cfg_t *cfg, const char *name, const char *value);
 
 /** Set a value of a boolean option given its name and index.
  *
@@ -1046,8 +1024,7 @@ DLLIMPORT void __export cfg_setstr(cfg_t *cfg, const char *name,
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
  */
-DLLIMPORT void __export cfg_setnstr(cfg_t *cfg, const char *name,
-                                    const char *value, unsigned int index);
+DLLIMPORT void __export cfg_setnstr(cfg_t *cfg, const char *name, const char *value, unsigned int index);
 
 /** Set values for a list option. All existing values are replaced
  * with the new ones.
@@ -1059,8 +1036,7 @@ DLLIMPORT void __export cfg_setnstr(cfg_t *cfg, const char *name,
  * option and the number of values must be equal to the nvalues
  * parameter.
  */
-DLLIMPORT void __export cfg_setlist(cfg_t *cfg, const char *name,
-                                    unsigned int nvalues, ...);
+DLLIMPORT void __export cfg_setlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...);
 
 DLLIMPORT int __export cfg_numopts(cfg_opt_t *opts);
 
@@ -1074,8 +1050,7 @@ DLLIMPORT int __export cfg_numopts(cfg_opt_t *opts);
  * option and the number of values must be equal to the nvalues
  * parameter.
  */
-DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name,
-                                    unsigned int nvalues, ...);
+DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...);
 
 /** Set an option (create an instance of an option).
  *
@@ -1087,8 +1062,7 @@ DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name,
  * @return Returns 0 if the option values where set correctly,
  * or -1 if an error occurred.
  */
-DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt,
-			       unsigned int nvalues, char **values);
+DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues, char **values);
 
 /** Set an option (create an instance of an option).
  *
@@ -1100,8 +1074,7 @@ DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt,
  * @return Returns 0 if the option values where set correctly,
  * or -1 if an error occurred.
  */
-DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name,
-			   unsigned int nvalues, char **values);
+DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, char **values);
 
 /** Removes and frees a config section, given a cfg_opt_t pointer.
  * @param opt The option structure (eg, as returned from cfg_getopt())
@@ -1116,8 +1089,7 @@ DLLIMPORT void __export cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index);
  * @param index Index of the section to remove. Zero based.
  * @see cfg_rmsec
  */
-DLLIMPORT void __export cfg_rmnsec(cfg_t *cfg, const char *name,
-                                   unsigned int index);
+DLLIMPORT void __export cfg_rmnsec(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Removes and frees a config section. This is the same as
  * calling cfg_rmnsec with index 0.
@@ -1144,8 +1116,7 @@ DLLIMPORT void __export cfg_opt_rmtsec(cfg_opt_t *opt, const char *title);
  * have been set for this option.
  * @see cfg_rmsec
  */
-DLLIMPORT void __export cfg_rmtsec(cfg_t *cfg, const char *name,
-                                   const char *title);
+DLLIMPORT void __export cfg_rmtsec(cfg_t *cfg, const char *name, const char *title);
 
 /** Default value print function.
  *
@@ -1159,8 +1130,7 @@ DLLIMPORT void __export cfg_rmtsec(cfg_t *cfg, const char *name,
  *
  * @see cfg_print, cfg_opt_print
  */
-DLLIMPORT void __export cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index,
-                                  FILE *fp);
+DLLIMPORT void __export cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index, FILE *fp);
 
 /** Print an option and its value to a file.
  * Same as cfg_opt_print, but with the indentation level specified.
@@ -1208,8 +1178,7 @@ DLLIMPORT void __export cfg_print(cfg_t *cfg, FILE *fp);
  *
  * @see cfg_print_func_t
  */
-DLLIMPORT cfg_print_func_t __export cfg_opt_set_print_func(cfg_opt_t *opt,
-                                                  cfg_print_func_t pf);
+DLLIMPORT cfg_print_func_t __export cfg_opt_set_print_func(cfg_opt_t *opt, cfg_print_func_t pf);
 
 /** Set a print callback function for an option given its name.
  *
@@ -1219,8 +1188,7 @@ DLLIMPORT cfg_print_func_t __export cfg_opt_set_print_func(cfg_opt_t *opt,
  *
  * @see cfg_print_func_t
  */
-DLLIMPORT cfg_print_func_t __export cfg_set_print_func(cfg_t *cfg, const char *name,
-                                              cfg_print_func_t pf);
+DLLIMPORT cfg_print_func_t __export cfg_set_print_func(cfg_t *cfg, const char *name, cfg_print_func_t pf);
 
 /** Register a validating callback function for an option.
  *
@@ -1230,15 +1198,12 @@ DLLIMPORT cfg_print_func_t __export cfg_set_print_func(cfg_t *cfg, const char *n
  *
  * @see cfg_validate_callback_t
  */
-DLLIMPORT cfg_validate_callback_t __export cfg_set_validate_func(cfg_t *cfg,
-                                                        const char *name,
-                                                        cfg_validate_callback_t vf);
+DLLIMPORT cfg_validate_callback_t __export cfg_set_validate_func(cfg_t *cfg, const char *name, cfg_validate_callback_t vf);
 
 #ifdef __cplusplus
 }
 #endif
-
-#endif
+#endif /* CONFUSE_H_ */
 
 /** @example ftpconf.c
  */

--- a/tests/env.c
+++ b/tests/env.c
@@ -6,36 +6,34 @@
 #include <stdlib.h>
 #include "check_confuse.h"
 
-cfg_opt_t opts[] =
-{
-        CFG_STR("parameter", NULL, CFGF_NONE),
-        CFG_END()
+cfg_opt_t opts[] = {
+	CFG_STR("parameter", NULL, CFGF_NONE),
+	CFG_END()
 };
 
-static int
-testconfig(const char *buf, const char *parameter)
+static int testconfig(const char *buf, const char *parameter)
 {
 	char *param;
 	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
-        if (!cfg)
-            return 0;
+
+	if (!cfg)
+		return 0;
 
 	if (cfg_parse_buf(cfg, buf) != CFG_SUCCESS)
-            return 0;
+		return 0;
 
-        param = cfg_getstr(cfg, "parameter");
-        if (!param)
-            return 0;
+	param = cfg_getstr(cfg, "parameter");
+	if (!param)
+		return 0;
 
-        if (strcmp(param, parameter) != 0)
-            return 0;
+	if (strcmp(param, parameter) != 0)
+		return 0;
 
 	cfg_free(cfg);
-        return 1;
+	return 1;
 }
 
-int
-main(void)
+int main(void)
 {
 #if defined(HAVE_SETENV) && defined(HAVE_UNSETENV)
 	fail_unless(setenv("MYVAR", "testing", 1) == 0);
@@ -47,33 +45,40 @@ main(void)
 #error "Not sure how to set environment variables."
 #endif
 
-        /* Check basic string parsing */
-        fail_unless(testconfig("parameter=\"abc\\ndef\"", "abc\ndef"));
-        fail_unless(testconfig("parameter=\"abc\\adef\"", "abc\adef"));
-        fail_unless(testconfig("parameter=\"abc\\040def\"", "abc def"));
-        fail_unless(testconfig("parameter=\"abc\\x20def\"", "abc def"));
-        fail_unless(testconfig("parameter=\"${}\"", ""));
+	/* Check basic string parsing */
+	fail_unless(testconfig("parameter=\"abc\\ndef\"", "abc\ndef"));
+	fail_unless(testconfig("parameter=\"abc\\adef\"", "abc\adef"));
+	fail_unless(testconfig("parameter=\"abc\\040def\"", "abc def"));
+	fail_unless(testconfig("parameter=\"abc\\x20def\"", "abc def"));
+	fail_unless(testconfig("parameter=\"${}\"", ""));
 
-        /* Check unquoted environment variable handling */
-        fail_unless(testconfig("parameter=${MYVAR}", "testing"));
-        fail_unless(testconfig("parameter=${MYVAR:-default}", "testing"));
-        fail_unless(testconfig("parameter=${MYUNSETVAR}", ""));
-        fail_unless(testconfig("parameter=${MYUNSETVAR:-default}", "default"));
+	/* Check unquoted environment variable handling */
+	fail_unless(testconfig("parameter=${MYVAR}", "testing"));
+	fail_unless(testconfig("parameter=${MYVAR:-default}", "testing"));
+	fail_unless(testconfig("parameter=${MYUNSETVAR}", ""));
+	fail_unless(testconfig("parameter=${MYUNSETVAR:-default}", "default"));
 
-        /* Check quoted environment variable handling */
-        fail_unless(testconfig("parameter=\"${MYVAR}\"", "testing"));
-        fail_unless(testconfig("parameter=\"${MYVAR:-default}\"", "testing"));
-        fail_unless(testconfig("parameter=\"${MYUNSETVAR}\"", ""));
-        fail_unless(testconfig("parameter=\"${MYUNSETVAR:-default}\"", "default"));
+	/* Check quoted environment variable handling */
+	fail_unless(testconfig("parameter=\"${MYVAR}\"", "testing"));
+	fail_unless(testconfig("parameter=\"${MYVAR:-default}\"", "testing"));
+	fail_unless(testconfig("parameter=\"${MYUNSETVAR}\"", ""));
+	fail_unless(testconfig("parameter=\"${MYUNSETVAR:-default}\"", "default"));
 
-        /* Check quoted environment variable handling in the middle of strings */
-        fail_unless(testconfig("parameter=\"text_${MYVAR}\"", "text_testing"));
-        fail_unless(testconfig("parameter=\"${MYVAR}_text\"", "testing_text"));
-        fail_unless(testconfig("parameter=\"start_${MYVAR}_end\"", "start_testing_end"));
+	/* Check quoted environment variable handling in the middle of strings */
+	fail_unless(testconfig("parameter=\"text_${MYVAR}\"", "text_testing"));
+	fail_unless(testconfig("parameter=\"${MYVAR}_text\"", "testing_text"));
+	fail_unless(testconfig("parameter=\"start_${MYVAR}_end\"", "start_testing_end"));
 
-        /* Check single quoted environment variable handling */
-        fail_unless(testconfig("parameter='${MYVAR}'", "${MYVAR}"));
+	/* Check single quoted environment variable handling */
+	fail_unless(testconfig("parameter='${MYVAR}'", "${MYVAR}"));
 
 	return 0;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/ignore_parm.c
+++ b/tests/ignore_parm.c
@@ -5,25 +5,23 @@
 #include <stdlib.h>
 #include "check_confuse.h"
 
-cfg_opt_t section_opts[] =
-{
+cfg_opt_t section_opts[] = {
 	CFG_STR("section_parameter", NULL, CFGF_NONE),
 	CFG_STR("__unknown", NULL, CFGF_NONE),
 	CFG_END()
 };
 
-cfg_opt_t opts[] =
-{
+cfg_opt_t opts[] = {
 	CFG_STR("parameter", NULL, CFGF_NONE),
 	CFG_STR("__unknown", NULL, CFGF_NONE),
 	CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
 	CFG_END()
 };
 
-static int
-testconfig(const char *buf)
+static int testconfig(const char *buf)
 {
 	cfg_t *cfg = cfg_init(opts, CFGF_IGNORE_UNKNOWN);
+
 	if (!cfg)
 		return 0;
 
@@ -34,15 +32,14 @@ testconfig(const char *buf)
 	return 1;
 }
 
-int
-main(void)
+int main(void)
 {
 	/* Sanity check cases that don't need to ignore parameters. */
 	fail_unless(testconfig("parameter=5"));
 	fail_unless(testconfig("parameter=5\n"
-				"section mysection {\n"
-				"section_parameter=1\n"
-				"}"));
+			       "section mysection {\n"
+			       "\tsection_parameter=1\n"
+			       "}"));
 
 	/* Ignore each type (no lists) */
 	fail_unless(testconfig("unknown_int=1"));
@@ -52,13 +49,20 @@ main(void)
 
 	/* Ignore multiple parameters */
 	fail_unless(testconfig("unknown_one=1\n"
-				"unknown_two=2\n"
-				"unknown_three=3\n"));
+			       "unknown_two=2\n"
+			       "unknown_three=3\n"));
 
 	/* Test ignore parameters in a section */
 	fail_unless(testconfig("section mysection {\n"
-				"unknown_section_parameter=1\n"
-				"}"));
+			       "\tunknown_section_parameter=1\n"
+			       "}"));
 	return 0;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/include.c
+++ b/tests/include.c
@@ -17,11 +17,11 @@ cfg_opt_t opts[] = {
 	CFG_END()
 };
 
-int
-main(void)
+int main(void)
 {
 	char *buf = "include (\"" SRC_DIR "/a.conf\")\n";
 	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+
 	fail_unless(cfg);
 	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 	fail_unless(cfg_size(cfg, "sec") == 1);
@@ -31,4 +31,3 @@ main(void)
 
 	return 0;
 }
-

--- a/tests/list_plus_syntax.c
+++ b/tests/list_plus_syntax.c
@@ -3,43 +3,51 @@
 
 int main(void)
 {
-    cfg_opt_t opts[] = {
-        CFG_STR_LIST("stringproperty", 0, CFGF_NONE),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_STR_LIST("stringproperty", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    int rc;
-    cfg_t *cfg = cfg_init(opts, CFGF_NONE);
-    fail_unless(cfg);
+	int rc;
+	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
 
-    rc = cfg_parse_buf(cfg,
-        " stringproperty = {\"this\"}\n"
-        " stringproperty += {\"that\"}\n"
-        " stringproperty += {\"other\"}\n");
+	fail_unless(cfg);
 
-    fail_unless(rc == CFG_SUCCESS);
+	rc = cfg_parse_buf(cfg,
+			   " stringproperty = {\"this\"}\n"
+			   " stringproperty += {\"that\"}\n"
+			   " stringproperty += {\"other\"}\n");
 
-    fail_unless(cfg_size(cfg, "stringproperty") == 3);
+	fail_unless(rc == CFG_SUCCESS);
 
-    fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 0), "this") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 1), "that") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 2), "other") == 0);
+	fail_unless(cfg_size(cfg, "stringproperty") == 3);
 
-    rc = cfg_parse_buf(cfg,
-            " stringproperty = \"this\"\n"
-            " stringproperty += \"that\"\n"
-            " stringproperty += \"other\"\n");
+	fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 0), "this") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 1), "that") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 2), "other") == 0);
 
-    fail_unless(rc == CFG_SUCCESS);
+	rc = cfg_parse_buf(cfg,
+			   " stringproperty = \"this\"\n"
+			   " stringproperty += \"that\"\n"
+			   " stringproperty += \"other\"\n");
 
-    fail_unless(cfg_size(cfg, "stringproperty") == 3);
+	fail_unless(rc == CFG_SUCCESS);
 
-    fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 0), "this") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 1), "that") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 2), "other") == 0);
+	fail_unless(cfg_size(cfg, "stringproperty") == 3);
 
-    cfg_free(cfg);
+	fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 0), "this") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 1), "that") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "stringproperty", 2), "other") == 0);
 
-    return 0;
+	cfg_free(cfg);
+
+	return 0;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/quote_before_print.c
+++ b/tests/quote_before_print.c
@@ -7,18 +7,17 @@
 
 #include "check_confuse.h"
 
-cfg_opt_t opts[] = 
-{
+cfg_opt_t opts[] = {
 	CFG_STR("parameter", NULL, CFGF_NONE),
 	CFG_END()
 };
 
-int
-main(void)
+int main(void)
 {
 	FILE *fp;
 	char *param;
 	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+
 	fail_unless(cfg);
 
 	/* set a string parameter to a string including a quote character
@@ -48,4 +47,3 @@ main(void)
 
 	return 0;
 }
-

--- a/tests/searchpath.c
+++ b/tests/searchpath.c
@@ -7,58 +7,62 @@
 const char spdir[] = SRC_DIR "/" "spdir";
 const char nodir[] = SRC_DIR "/" "no-such-directory";
 
-int
-main(void)
+int main(void)
 {
-    cfg_t *cfg;
-    cfg_t *sec;
+	cfg_t *cfg;
+	cfg_t *sec;
 
-    cfg_opt_t sec_opts[] = 
-    {
-	CFG_FUNC("include", cfg_include),
-        CFG_INT("val", 0, CFGF_NONE),
-        CFG_END()
-    };
+	cfg_opt_t sec_opts[] = {
+		CFG_FUNC("include", cfg_include),
+		CFG_INT("val", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = 
-    {
-	CFG_FUNC("include", cfg_include),
-	CFG_SEC("sec", sec_opts, CFGF_MULTI | CFGF_TITLE),
-	CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_FUNC("include", cfg_include),
+		CFG_SEC("sec", sec_opts, CFGF_MULTI | CFGF_TITLE),
+		CFG_END()
+	};
 
-    cfg = cfg_init(opts, 0);
+	cfg = cfg_init(opts, 0);
 
-    /* 
-       include some non-existent directories to 
-       force linked-list traversal
-    */
+	/*
+	 * include some non-existent directories to
+	 * force linked-list traversal
+	 */
 
-    fail_unless(cfg_add_searchpath(cfg, nodir) == 0);
-    fail_unless(cfg_add_searchpath(cfg, spdir) == 0);
-    fail_unless(cfg_add_searchpath(cfg, nodir) == 0);
+	fail_unless(cfg_add_searchpath(cfg, nodir) == 0);
+	fail_unless(cfg_add_searchpath(cfg, spdir) == 0);
+	fail_unless(cfg_add_searchpath(cfg, nodir) == 0);
 
-    fail_unless(cfg_parse(cfg, "spa.conf") == 0);
+	fail_unless(cfg_parse(cfg, "spa.conf") == 0);
 
-    fail_unless(cfg_size(cfg, "sec") == 3);
+	fail_unless(cfg_size(cfg, "sec") == 3);
 
-    sec = cfg_getnsec(cfg, "sec", 0);
-    fail_unless(sec != 0);
-    fail_unless(strcmp(cfg_title(sec), "acfg") == 0);
-    fail_unless(cfg_getint(sec, "val") == 5);
+	sec = cfg_getnsec(cfg, "sec", 0);
+	fail_unless(sec != 0);
+	fail_unless(strcmp(cfg_title(sec), "acfg") == 0);
+	fail_unless(cfg_getint(sec, "val") == 5);
 
-    sec = cfg_getnsec(cfg, "sec", 1);
-    fail_unless(sec != 0);
-    fail_unless(strcmp(cfg_title(sec), "bcfg") == 0);
-    fail_unless(cfg_getint(sec, "val") == 6);
+	sec = cfg_getnsec(cfg, "sec", 1);
+	fail_unless(sec != 0);
+	fail_unless(strcmp(cfg_title(sec), "bcfg") == 0);
+	fail_unless(cfg_getint(sec, "val") == 6);
 
-    sec = cfg_getnsec(cfg, "sec", 2);
-    fail_unless(sec != 0);
-    fail_unless(strcmp(cfg_title(sec), "ccfg") == 0);
-    fail_unless(cfg_getint(sec, "val") == 7);
+	sec = cfg_getnsec(cfg, "sec", 2);
+	fail_unless(sec != 0);
+	fail_unless(strcmp(cfg_title(sec), "ccfg") == 0);
+	fail_unless(cfg_getint(sec, "val") == 7);
 
-    cfg_free(cfg);
+	cfg_free(cfg);
 
-    return 0;
+	return 0;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/section_remove.c
+++ b/tests/section_remove.c
@@ -3,49 +3,54 @@
 
 int main(void)
 {
-    static cfg_opt_t section_opts[] = {
-        CFG_STR("prop", 0, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t section_opts[] = {
+		CFG_STR("prop", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = {
-        CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
+		CFG_END()
+	};
 
-    const char *config_data =
-        "section title_one { prop = 'value_one' }\n"
-        "section title_two { prop = 'value_two' }\n"
-        "section title_one { prop = 'value_one' }\n";
+	const char *config_data =
+		"section title_one { prop = 'value_one' }\n"
+		"section title_two { prop = 'value_two' }\n"
+		"section title_one { prop = 'value_one' }\n";
 
-    int rc;
-    cfg_t *cfg = cfg_init(opts, CFGF_NONE);
-    fail_unless(cfg);
+	int rc;
+	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
 
-    rc = cfg_parse_buf(cfg, config_data);
-    fail_unless(rc == CFG_SUCCESS);
+	fail_unless(cfg);
 
-    cfg_rmtsec(cfg, "section", "title_two");
-    fail_unless(cfg_size(cfg, "section") == 1);
-    fail_unless(
-	strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_one") == 0);
+	rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(rc == CFG_SUCCESS);
 
-    cfg_free(cfg);
+	cfg_rmtsec(cfg, "section", "title_two");
+	fail_unless(cfg_size(cfg, "section") == 1);
+	fail_unless(strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_one") == 0);
 
+	cfg_free(cfg);
 
-    cfg = cfg_init(opts, CFGF_NONE);
-    fail_unless(cfg);
+	cfg = cfg_init(opts, CFGF_NONE);
+	fail_unless(cfg);
 
-    rc = cfg_parse_buf(cfg, config_data);
+	rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(rc == CFG_SUCCESS);
 
-    fail_unless(rc == CFG_SUCCESS);
+	cfg_rmsec(cfg, "section");
+	fail_unless(cfg_size(cfg, "section") == 1);
+	fail_unless(strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_two") == 0);
 
-    cfg_rmsec(cfg, "section");
-    fail_unless(cfg_size(cfg, "section") == 1);
-    fail_unless(
-	strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_two") == 0);
+	cfg_free(cfg);
 
-    cfg_free(cfg);
-
-    return 0;
+	return 0;
 }
+
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/section_title_dupes.c
+++ b/tests/section_title_dupes.c
@@ -3,52 +3,56 @@
 
 int main(void)
 {
-    static cfg_opt_t section_opts[] = {
-        CFG_STR("prop", 0, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t section_opts[] = {
+		CFG_STR("prop", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = {
-        CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_SEC("section", section_opts, CFGF_TITLE | CFGF_MULTI),
+		CFG_END()
+	};
 
-    cfg_opt_t opts_no_dupes[] = {
-        CFG_SEC("section", section_opts,
-	    CFGF_TITLE | CFGF_MULTI | CFGF_NO_TITLE_DUPES),
-        CFG_END()
-    };
+	cfg_opt_t opts_no_dupes[] = {
+		CFG_SEC("section", section_opts,
+			CFGF_TITLE | CFGF_MULTI | CFGF_NO_TITLE_DUPES),
+		CFG_END()
+	};
 
-    const char *config_data = 
-        "section title_one { prop = 'value_one' }\n"
-        "section title_two { prop = 'value_two' }\n"
-        "section title_one { prop = 'value_one' }\n";
+	const char *config_data =
+		"section title_one { prop = 'value_one' }\n"
+		"section title_two { prop = 'value_two' }\n"
+		"section title_one { prop = 'value_one' }\n";
 
-    int rc;
-    cfg_t *cfg = cfg_init(opts, CFGF_NONE);
-    fail_unless(cfg);
+	int rc;
+	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
 
-    rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(cfg);
 
-    fail_unless(rc == CFG_SUCCESS);
+	rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(rc == CFG_SUCCESS);
 
-    fail_unless(cfg_size(cfg, "section") == 2);
+	fail_unless(cfg_size(cfg, "section") == 2);
+	fail_unless(strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_one") == 0);
+	fail_unless(strcmp(cfg_title(cfg_getnsec(cfg, "section", 1)), "title_two") == 0);
 
-    fail_unless(
-	strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_one") == 0);
-    fail_unless(
-	strcmp(cfg_title(cfg_getnsec(cfg, "section", 1)), "title_two") == 0);
+	cfg_free(cfg);
 
-    cfg_free(cfg);
+	cfg = cfg_init(opts_no_dupes, CFGF_NONE);
+	fail_unless(cfg);
 
-    cfg = cfg_init(opts_no_dupes, CFGF_NONE);
-    fail_unless(cfg);
+	rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(rc == CFG_PARSE_ERROR);
 
-    rc = cfg_parse_buf(cfg, config_data);
-    fail_unless(rc == CFG_PARSE_ERROR);
+	cfg_free(cfg);
 
-    cfg_free(cfg);
-    
-    return 0;
+	return 0;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/single_title_sections.c
+++ b/tests/single_title_sections.c
@@ -13,13 +13,12 @@ cfg_opt_t opts[] = {
 	CFG_END()
 };
 
-int
-main(void)
+int main(void)
 {
 	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+
 	fail_unless(cfg);
 	cfg_free(cfg);
 
 	return 0;
 }
-

--- a/tests/suite_dup.c
+++ b/tests/suite_dup.c
@@ -3,51 +3,47 @@
 
 static cfg_t *create_config(void)
 {
-    static cfg_opt_t sec_opts[] = 
-    {
-        CFG_INT("a", 1, CFGF_NONE),
-        CFG_INT("b", 2, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t sec_opts[] = {
+		CFG_INT("a", 1, CFGF_NONE),
+		CFG_INT("b", 2, CFGF_NONE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = 
-    {
-        CFG_SEC("sec", sec_opts, CFGF_MULTI | CFGF_TITLE),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_SEC("sec", sec_opts, CFGF_MULTI | CFGF_TITLE),
+		CFG_END()
+	};
 
-    return cfg_init(opts, 0);
+	return cfg_init(opts, 0);
 }
 
-int
-main(void)
+int main(void)
 {
-    cfg_t *acfg, *bcfg;
-    cfg_t *sec;
+	cfg_t *acfg, *bcfg;
+	cfg_t *sec;
 
-    acfg = create_config();
-    fail_unless(cfg_parse(acfg, SRC_DIR "/a.conf") == 0);
+	acfg = create_config();
+	fail_unless(cfg_parse(acfg, SRC_DIR "/a.conf") == 0);
 
-    bcfg = create_config();
-    fail_unless(cfg_parse(bcfg, SRC_DIR "/b.conf") == 0);
+	bcfg = create_config();
+	fail_unless(cfg_parse(bcfg, SRC_DIR "/b.conf") == 0);
 
-    sec = cfg_getnsec(acfg, "sec", 0);
-    fail_unless(sec != 0);
-    fail_unless(cfg_size(acfg, "sec") == 1);
-    fail_unless(strcmp(cfg_title(sec), "acfg") == 0);
-    fail_unless(cfg_getint(sec, "a") == 5);
-    fail_unless(cfg_getint(sec, "b") == 2);
+	sec = cfg_getnsec(acfg, "sec", 0);
+	fail_unless(sec != 0);
+	fail_unless(cfg_size(acfg, "sec") == 1);
+	fail_unless(strcmp(cfg_title(sec), "acfg") == 0);
+	fail_unless(cfg_getint(sec, "a") == 5);
+	fail_unless(cfg_getint(sec, "b") == 2);
 
-    sec = cfg_getnsec(bcfg, "sec", 0);
-    fail_unless(sec != 0);
-    fail_unless(cfg_size(bcfg, "sec") == 1);
-    fail_unless(strcmp(cfg_title(sec), "bcfg") == 0);
-    fail_unless(cfg_getint(sec, "a") == 1);
-    fail_unless(cfg_getint(sec, "b") == 9);
+	sec = cfg_getnsec(bcfg, "sec", 0);
+	fail_unless(sec != 0);
+	fail_unless(cfg_size(bcfg, "sec") == 1);
+	fail_unless(strcmp(cfg_title(sec), "bcfg") == 0);
+	fail_unless(cfg_getint(sec, "a") == 1);
+	fail_unless(cfg_getint(sec, "b") == 9);
 
-    cfg_free(acfg);
-    cfg_free(bcfg);
+	cfg_free(acfg);
+	cfg_free(bcfg);
 
-    return 0;
+	return 0;
 }
-

--- a/tests/suite_func.c
+++ b/tests/suite_func.c
@@ -9,64 +9,61 @@ static int func_alias_called = 0;
 
 static int func_alias(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
 {
-    func_alias_called = 1;
+	func_alias_called = 1;
 
-    fail_unless(cfg != 0);
-    fail_unless(opt != 0);
-    fail_unless(strcmp(opt->name, "alias") == 0);
-    fail_unless(opt->type == CFGT_FUNC);
-    fail_unless(argv != 0);
-    fail_unless(strcmp(argv[0], "ll") == 0);
-    fail_unless(strcmp(argv[1], "ls -l") == 0);
+	fail_unless(cfg != 0);
+	fail_unless(opt != 0);
+	fail_unless(strcmp(opt->name, "alias") == 0);
+	fail_unless(opt->type == CFGT_FUNC);
+	fail_unless(argv != 0);
+	fail_unless(strcmp(argv[0], "ll") == 0);
+	fail_unless(strcmp(argv[1], "ls -l") == 0);
 
-    if(argc != 2)
-        return -1;
+	if (argc != 2)
+		return -1;
 
-    return 0;
+	return 0;
 }
 
 static void func_setup(void)
 {
-    cfg_opt_t opts[] = 
-    {
-        CFG_FUNC("alias", func_alias),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_FUNC("alias", func_alias),
+		CFG_END()
+	};
 
-    cfg = cfg_init(opts, 0);
-    /* cfg_set_error_function(cfg, suppress_errors); */
+	cfg = cfg_init(opts, 0);
+	/* cfg_set_error_function(cfg, suppress_errors); */
 }
 
 static void func_teardown(void)
 {
-    cfg_free(cfg);
+	cfg_free(cfg);
 }
 
 static void func_test(void)
 {
-    char *buf;
+	char *buf;
 
-    func_alias_called = 0;
-    buf = "alias(ll, 'ls -l')";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(func_alias_called == 1);
+	func_alias_called = 0;
+	buf = "alias(ll, 'ls -l')";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(func_alias_called == 1);
 
-    func_alias_called = 0;
-    buf = "alias(ll, 'ls -l', 2)";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
-    fail_unless(func_alias_called == 1);
+	func_alias_called = 0;
+	buf = "alias(ll, 'ls -l', 2)";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	fail_unless(func_alias_called == 1);
 
-    buf = "unalias(ll, 'ls -l')";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "unalias(ll, 'ls -l')";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 }
 
-int
-main(void)
+int main(void)
 {
-    func_setup();
-    func_test();
-    func_teardown();
+	func_setup();
+	func_test();
+	func_teardown();
 
-    return 0;
+	return 0;
 }
-

--- a/tests/suite_list.c
+++ b/tests/suite_list.c
@@ -6,380 +6,383 @@ static int numopts = 0;
 
 static void list_setup(void)
 {
-    static cfg_opt_t subsec_opts[] = 
-    {
-        CFG_STR_LIST("subsubstring", 0, CFGF_NONE),
-        CFG_INT_LIST("subsubinteger", 0, CFGF_NONE),
-        CFG_FLOAT_LIST("subsubfloat", 0, CFGF_NONE),
-        CFG_BOOL_LIST("subsubbool", 0, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t subsec_opts[] = {
+		CFG_STR_LIST("subsubstring", 0, CFGF_NONE),
+		CFG_INT_LIST("subsubinteger", 0, CFGF_NONE),
+		CFG_FLOAT_LIST("subsubfloat", 0, CFGF_NONE),
+		CFG_BOOL_LIST("subsubbool", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    static cfg_opt_t sec_opts[] =
-    {
-        CFG_STR_LIST("substring", "{subdefault1, subdefault2}", CFGF_NONE),
-        CFG_INT_LIST("subinteger", "{17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 300}", CFGF_NONE), /* 14 values */
-        CFG_FLOAT_LIST("subfloat", "{8.37}", CFGF_NONE),
-        CFG_BOOL_LIST("subbool", "{true}", CFGF_NONE),
-        CFG_SEC("subsection", subsec_opts, CFGF_MULTI | CFGF_TITLE),
-        CFG_END()
-    };
+	static cfg_opt_t sec_opts[] = {
+		CFG_STR_LIST("substring", "{subdefault1, subdefault2}", CFGF_NONE),
+		CFG_INT_LIST("subinteger", "{17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 300}", CFGF_NONE),	/* 14 values */
+		CFG_FLOAT_LIST("subfloat", "{8.37}", CFGF_NONE),
+		CFG_BOOL_LIST("subbool", "{true}", CFGF_NONE),
+		CFG_SEC("subsection", subsec_opts, CFGF_MULTI | CFGF_TITLE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = 
-    {
-        CFG_STR_LIST("string", "{default1, default2, default3}", CFGF_NONE),
-        CFG_INT_LIST("integer", "{4711, 123456789}", CFGF_NONE),
-        CFG_FLOAT_LIST("float", "{0.42}", CFGF_NONE),
-        CFG_BOOL_LIST("bool", "{false, true, no, yes, off, on}", CFGF_NONE),
-        CFG_SEC("section", sec_opts, CFGF_MULTI),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_STR_LIST("string", "{default1, default2, default3}", CFGF_NONE),
+		CFG_INT_LIST("integer", "{4711, 123456789}", CFGF_NONE),
+		CFG_FLOAT_LIST("float", "{0.42}", CFGF_NONE),
+		CFG_BOOL_LIST("bool", "{false, true, no, yes, off, on}", CFGF_NONE),
+		CFG_SEC("section", sec_opts, CFGF_MULTI),
+		CFG_END()
+	};
 
-    cfg = cfg_init(opts, 0);
-    numopts = cfg_numopts(opts);
-    fail_unless(numopts == 5);
+	cfg = cfg_init(opts, 0);
+	numopts = cfg_numopts(opts);
+	fail_unless(numopts == 5);
 
-    memset(opts, 0, sizeof(opts));
-    memset(sec_opts, 0, sizeof(sec_opts));
-    memset(subsec_opts, 0, sizeof(subsec_opts));
+	memset(opts, 0, sizeof(opts));
+	memset(sec_opts, 0, sizeof(sec_opts));
+	memset(subsec_opts, 0, sizeof(subsec_opts));
 }
 
 static void list_teardown(void)
 {
-    cfg_free(cfg);
+	cfg_free(cfg);
 }
 
 static void list_string_test(void)
 {
-    char *buf;
-    char *multi[2];
+	char *buf;
+	char *multi[2];
 
-    fail_unless(cfg_size(cfg, "string") == 3);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "string")) == 3);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "default1") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "default2") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 2), "default3") == 0);
-    buf = "string = {\"manually\", 'set'}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "string") == 2);
-    fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "set") == 0);
-    cfg_setstr(cfg, "string", "manually set");
-    fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually set") == 0);
-    cfg_setnstr(cfg, "string", "foobar", 1);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "foobar") == 0);
+	fail_unless(cfg_size(cfg, "string") == 3);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "string")) == 3);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "default1") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "default2") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 2), "default3") == 0);
+	buf = "string = {\"manually\", 'set'}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "string") == 2);
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "set") == 0);
+	cfg_setstr(cfg, "string", "manually set");
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually set") == 0);
+	cfg_setnstr(cfg, "string", "foobar", 1);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "foobar") == 0);
 
-    cfg_addlist(cfg, "string", 3, "foo", "bar", "baz");
-    fail_unless(cfg_size(cfg, "string") == 5);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 3), "bar") == 0);
+	cfg_addlist(cfg, "string", 3, "foo", "bar", "baz");
+	fail_unless(cfg_size(cfg, "string") == 5);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 3), "bar") == 0);
 
-    cfg_setlist(cfg, "string", 3, "baz", "foo", "bar");
-    fail_unless(cfg_size(cfg, "string") == 3);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "baz") == 0);
+	cfg_setlist(cfg, "string", 3, "baz", "foo", "bar");
+	fail_unless(cfg_size(cfg, "string") == 3);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "baz") == 0);
 
-    buf = "string += {gaz, 'onk'}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "string") == 5);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 3), "gaz") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 4), "onk") == 0);
+	buf = "string += {gaz, 'onk'}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "string") == 5);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 3), "gaz") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 4), "onk") == 0);
 
-    multi[0] = "bar";
-    multi[1] = "foo";
-    fail_unless(cfg_setmulti(cfg, "string", 2, multi) == 0);
-    fail_unless(cfg_size(cfg, "string") == 2);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "bar") == 0);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "foo") == 0);
+	multi[0] = "bar";
+	multi[1] = "foo";
+	fail_unless(cfg_setmulti(cfg, "string", 2, multi) == 0);
+	fail_unless(cfg_size(cfg, "string") == 2);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "bar") == 0);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 1), "foo") == 0);
 }
 
 static void list_integer_test(void)
 {
-    char *buf;
-    char *multi[3];
+	char *buf;
+	char *multi[3];
 
-    fail_unless(cfg_size(cfg, "integer") == 2);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "integer")) == 2);
+	fail_unless(cfg_size(cfg, "integer") == 2);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "integer")) == 2);
 
-    fail_unless(cfg_getint(cfg, "integer") == 4711);
-    fail_unless(cfg_getnint(cfg, "integer", 1) == 123456789);
-    buf = "integer = {-46}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "integer") == 1);
-    fail_unless(cfg_getnint(cfg, "integer", 0) == -46);
-    cfg_setnint(cfg, "integer", 999999, 1);
-    fail_unless(cfg_size(cfg, "integer") == 2);
-    fail_unless(cfg_getnint(cfg, "integer", 1) == 999999);
+	fail_unless(cfg_getint(cfg, "integer") == 4711);
+	fail_unless(cfg_getnint(cfg, "integer", 1) == 123456789);
+	buf = "integer = {-46}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "integer") == 1);
+	fail_unless(cfg_getnint(cfg, "integer", 0) == -46);
+	cfg_setnint(cfg, "integer", 999999, 1);
+	fail_unless(cfg_size(cfg, "integer") == 2);
+	fail_unless(cfg_getnint(cfg, "integer", 1) == 999999);
 
-    cfg_addlist(cfg, "integer", 3, 11, 22, 33);
-    fail_unless(cfg_size(cfg, "integer") == 5);
-    fail_unless(cfg_getnint(cfg, "integer", 3) == 22);
+	cfg_addlist(cfg, "integer", 3, 11, 22, 33);
+	fail_unless(cfg_size(cfg, "integer") == 5);
+	fail_unless(cfg_getnint(cfg, "integer", 3) == 22);
 
-    cfg_setlist(cfg, "integer", 3, 11, 22, 33);
-    fail_unless(cfg_size(cfg, "integer") == 3);
-    fail_unless(cfg_getnint(cfg, "integer", 0) == 11);
+	cfg_setlist(cfg, "integer", 3, 11, 22, 33);
+	fail_unless(cfg_size(cfg, "integer") == 3);
+	fail_unless(cfg_getnint(cfg, "integer", 0) == 11);
 
-    buf = "integer += {-1234567890, 1234567890}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "integer") == 5);
-    fail_unless(cfg_getnint(cfg, "integer", 3) == -1234567890);
-    fail_unless(cfg_getnint(cfg, "integer", 4) == 1234567890);
+	buf = "integer += {-1234567890, 1234567890}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "integer") == 5);
+	fail_unless(cfg_getnint(cfg, "integer", 3) == -1234567890);
+	fail_unless(cfg_getnint(cfg, "integer", 4) == 1234567890);
 
-    multi[0] = "42";
-    multi[1] = "17";
-    fail_unless(cfg_setmulti(cfg, "integer", 2, multi) == 0);
-    fail_unless(cfg_size(cfg, "integer") == 2);
-    fail_unless(cfg_getnint(cfg, "integer", 0) == 42);
-    fail_unless(cfg_getnint(cfg, "integer", 1) == 17);
+	multi[0] = "42";
+	multi[1] = "17";
+	fail_unless(cfg_setmulti(cfg, "integer", 2, multi) == 0);
+	fail_unless(cfg_size(cfg, "integer") == 2);
+	fail_unless(cfg_getnint(cfg, "integer", 0) == 42);
+	fail_unless(cfg_getnint(cfg, "integer", 1) == 17);
 
-    multi[0] = "17";
-    multi[1] = "bad";
-    multi[2] = "42";
-    fail_unless(cfg_setmulti(cfg, "integer", 3, multi) == -1);
-    fail_unless(cfg_size(cfg, "integer") == 2);
-    fail_unless(cfg_getnint(cfg, "integer", 0) == 42);
-    fail_unless(cfg_getnint(cfg, "integer", 1) == 17);
+	multi[0] = "17";
+	multi[1] = "bad";
+	multi[2] = "42";
+	fail_unless(cfg_setmulti(cfg, "integer", 3, multi) == -1);
+	fail_unless(cfg_size(cfg, "integer") == 2);
+	fail_unless(cfg_getnint(cfg, "integer", 0) == 42);
+	fail_unless(cfg_getnint(cfg, "integer", 1) == 17);
 }
 
 static void list_float_test(void)
 {
-    char *buf;
-    char *multi[3];
+	char *buf;
+	char *multi[3];
 
-    fail_unless(cfg_size(cfg, "float") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 1);
+	fail_unless(cfg_size(cfg, "float") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 1);
 
-    fail_unless(cfg_getfloat(cfg, "float") == 0.42);
-    fail_unless(cfg_getnfloat(cfg, "float", 0) == 0.42);
+	fail_unless(cfg_getfloat(cfg, "float") == 0.42);
+	fail_unless(cfg_getnfloat(cfg, "float", 0) == 0.42);
 
-    buf = "float = {-46.777, 0.1, 0.2, 0.17, 17.123}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 5);
-    fail_unless(cfg_getnfloat(cfg, "float", 0) == -46.777);
-    fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.1);
-    fail_unless(cfg_getnfloat(cfg, "float", 2) == 0.2);
-    fail_unless(cfg_getnfloat(cfg, "float", 3) == 0.17);
-    fail_unless(cfg_getnfloat(cfg, "float", 4) == 17.123);
+	buf = "float = {-46.777, 0.1, 0.2, 0.17, 17.123}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 5);
+	fail_unless(cfg_getnfloat(cfg, "float", 0) == -46.777);
+	fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.1);
+	fail_unless(cfg_getnfloat(cfg, "float", 2) == 0.2);
+	fail_unless(cfg_getnfloat(cfg, "float", 3) == 0.17);
+	fail_unless(cfg_getnfloat(cfg, "float", 4) == 17.123);
 
-    cfg_setnfloat(cfg, "float", 5.1234e2, 1);
-    fail_unless(cfg_getnfloat(cfg, "float", 1) == 5.1234e2);
+	cfg_setnfloat(cfg, "float", 5.1234e2, 1);
+	fail_unless(cfg_getnfloat(cfg, "float", 1) == 5.1234e2);
 
-    cfg_addlist(cfg, "float", 1, 11.2233);
-    fail_unless(cfg_size(cfg, "float") == 6);
-    fail_unless(cfg_getnfloat(cfg, "float", 5) == 11.2233);
+	cfg_addlist(cfg, "float", 1, 11.2233);
+	fail_unless(cfg_size(cfg, "float") == 6);
+	fail_unless(cfg_getnfloat(cfg, "float", 5) == 11.2233);
 
-    cfg_setlist(cfg, "float", 2, .3, -18.17e-7);
-    fail_unless(cfg_size(cfg, "float") == 2);
-    fail_unless(cfg_getnfloat(cfg, "float", 0) == 0.3);
-    fail_unless(cfg_getnfloat(cfg, "float", 1) == -18.17e-7);
+	cfg_setlist(cfg, "float", 2, .3, -18.17e-7);
+	fail_unless(cfg_size(cfg, "float") == 2);
+	fail_unless(cfg_getnfloat(cfg, "float", 0) == 0.3);
+	fail_unless(cfg_getnfloat(cfg, "float", 1) == -18.17e-7);
 
-    buf = "float += {64.64, 1234.567890}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "float") == 4);
-    fail_unless(cfg_getnfloat(cfg, "float", 2) == 64.64);
-    fail_unless(cfg_getnfloat(cfg, "float", 3) == 1234.567890);
+	buf = "float += {64.64, 1234.567890}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "float") == 4);
+	fail_unless(cfg_getnfloat(cfg, "float", 2) == 64.64);
+	fail_unless(cfg_getnfloat(cfg, "float", 3) == 1234.567890);
 
-    multi[0] = "42";
-    multi[1] = "0.17";
-    fail_unless(cfg_setmulti(cfg, "float", 2, multi) == 0);
-    fail_unless(cfg_size(cfg, "float") == 2);
-    fail_unless(cfg_getnfloat(cfg, "float", 0) == 42);
-    fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.17);
+	multi[0] = "42";
+	multi[1] = "0.17";
+	fail_unless(cfg_setmulti(cfg, "float", 2, multi) == 0);
+	fail_unless(cfg_size(cfg, "float") == 2);
+	fail_unless(cfg_getnfloat(cfg, "float", 0) == 42);
+	fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.17);
 
-    multi[0] = "42";
-    multi[1] = "bad";
-    multi[2] = "0.17";
-    fail_unless(cfg_setmulti(cfg, "float", 3, multi) == -1);
-    fail_unless(cfg_size(cfg, "float") == 2);
-    fail_unless(cfg_getnfloat(cfg, "float", 0) == 42);
-    fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.17);
+	multi[0] = "42";
+	multi[1] = "bad";
+	multi[2] = "0.17";
+	fail_unless(cfg_setmulti(cfg, "float", 3, multi) == -1);
+	fail_unless(cfg_size(cfg, "float") == 2);
+	fail_unless(cfg_getnfloat(cfg, "float", 0) == 42);
+	fail_unless(cfg_getnfloat(cfg, "float", 1) == 0.17);
 }
 
 static void list_bool_test(void)
 {
-    char *buf;
-    char *multi[3];
+	char *buf;
+	char *multi[3];
 
-    fail_unless(cfg_size(cfg, "bool") == 6);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 6);
-    fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 2) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 3) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_true);
+	fail_unless(cfg_size(cfg, "bool") == 6);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 6);
+	fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 2) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 3) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_true);
 
-    buf = "bool = {yes, yes, no, false, true}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "bool") == 5);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 2) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 3) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_true);
+	buf = "bool = {yes, yes, no, false, true}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "bool") == 5);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 2) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 3) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_true);
 
-    cfg_setbool(cfg, "bool", cfg_false);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
-    cfg_setnbool(cfg, "bool", cfg_false, 1);
-    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
+	cfg_setbool(cfg, "bool", cfg_false);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+	cfg_setnbool(cfg, "bool", cfg_false, 1);
+	fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
 
-    cfg_addlist(cfg, "bool", 2, cfg_true, cfg_false);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 7);
-    fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_true);
+	cfg_addlist(cfg, "bool", 2, cfg_true, cfg_false);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 7);
+	fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_true);
 
-    cfg_setlist(cfg, "bool", 4, cfg_true, cfg_true, cfg_false, cfg_true);
-    fail_unless(cfg_size(cfg, "bool") == 4);
-    fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 2) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 3) == cfg_true);
+	cfg_setlist(cfg, "bool", 4, cfg_true, cfg_true, cfg_false, cfg_true);
+	fail_unless(cfg_size(cfg, "bool") == 4);
+	fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 2) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 3) == cfg_true);
 
-    buf = "bool += {false, false}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "bool") == 6);
-    fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_false);
-    fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_false);
+	buf = "bool += {false, false}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "bool") == 6);
+	fail_unless(cfg_getnbool(cfg, "bool", 4) == cfg_false);
+	fail_unless(cfg_getnbool(cfg, "bool", 5) == cfg_false);
 
-    multi[0] = "true";
-    multi[1] = "no";
-    fail_unless(cfg_setmulti(cfg, "bool", 2, multi) == 0);
-    fail_unless(cfg_size(cfg, "bool") == 2);
-    fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
+	multi[0] = "true";
+	multi[1] = "no";
+	fail_unless(cfg_setmulti(cfg, "bool", 2, multi) == 0);
+	fail_unless(cfg_size(cfg, "bool") == 2);
+	fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
 
-    multi[0] = "false";
-    multi[1] = "maybe";
-    multi[2] = "yes";
-    fail_unless(cfg_setmulti(cfg, "bool", 3, multi) == -1);
-    fail_unless(cfg_size(cfg, "bool") == 2);
-    fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
-    fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
+	multi[0] = "false";
+	multi[1] = "maybe";
+	multi[2] = "yes";
+	fail_unless(cfg_setmulti(cfg, "bool", 3, multi) == -1);
+	fail_unless(cfg_size(cfg, "bool") == 2);
+	fail_unless(cfg_getnbool(cfg, "bool", 0) == cfg_true);
+	fail_unless(cfg_getnbool(cfg, "bool", 1) == cfg_false);
 }
 
 static void list_section_test(void)
 {
-    char *buf;
-    cfg_t *sec, *subsec;
-    cfg_opt_t *opt;
+	char *buf;
+	cfg_t *sec, *subsec;
+	cfg_opt_t *opt;
 
-    /* size should be 0 before any section has been parsed. Since the
-     * CFGF_MULTI flag is set, there are no default sections.
-     */
-    fail_unless(cfg_size(cfg, "section") == 0);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "section")) == 0);
-    fail_unless(cfg_size(cfg, "section|subsection") == 0);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "section|subsection")) == 0);
+	/* size should be 0 before any section has been parsed. Since the
+	 * CFGF_MULTI flag is set, there are no default sections.
+	 */
+	fail_unless(cfg_size(cfg, "section") == 0);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "section")) == 0);
+	fail_unless(cfg_size(cfg, "section|subsection") == 0);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "section|subsection")) == 0);
 
-    buf = "section {}"; /* add a section with default values */
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "section") == 1);
-    
-    sec = cfg_getsec(cfg, "section");
-    fail_unless(sec != 0);
-    fail_unless(strcmp(sec->name, "section") == 0);
-    fail_unless(cfg_title(sec) == 0);
+	buf = "section {}";	/* add a section with default values */
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "section") == 1);
 
-    opt = cfg_getopt(sec, "subsection");
-    fail_unless(opt != 0);
-    fail_unless(cfg_opt_size(opt) == 0);
-    fail_unless(cfg_size(sec, "subsection") == 0);
-    
-    fail_unless(strcmp(cfg_getnstr(sec, "substring", 0), "subdefault1") == 0);
-    subsec = cfg_getsec(cfg, "section|subsection");
-    fail_unless(subsec == 0);
+	sec = cfg_getsec(cfg, "section");
+	fail_unless(sec != 0);
+	fail_unless(strcmp(sec->name, "section") == 0);
+	fail_unless(cfg_title(sec) == 0);
 
-    buf = "section { subsection 'foo' { subsubfloat = {1.2, 3.4, 5.6} } }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(cfg, "section") == 2);
+	opt = cfg_getopt(sec, "subsection");
+	fail_unless(opt != 0);
+	fail_unless(cfg_opt_size(opt) == 0);
+	fail_unless(cfg_size(sec, "subsection") == 0);
 
-    sec = cfg_getnsec(cfg, "section", 1);
-    fail_unless(sec != 0);
-    fail_unless(strcmp(cfg_title(cfg_getnsec(sec, "subsection", 0)), "foo") == 0);
-    fail_unless(cfg_size(sec, "subinteger") == 14);
+	fail_unless(strcmp(cfg_getnstr(sec, "substring", 0), "subdefault1") == 0);
+	subsec = cfg_getsec(cfg, "section|subsection");
+	fail_unless(subsec == 0);
 
-    subsec = cfg_getsec(sec, "subsection");
-    fail_unless(cfg_size(subsec, "subsubfloat") == 3);
-    fail_unless(cfg_getnfloat(subsec, "subsubfloat", 2) == 5.6);
-    fail_unless(cfg_getnstr(subsec, "subsubstring", 0) == 0);
+	buf = "section { subsection 'foo' { subsubfloat = {1.2, 3.4, 5.6} } }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "section") == 2);
 
-    sec = cfg_getnsec(cfg, "section", 0);
-    fail_unless(sec != 0);
-    fail_unless(cfg_size(sec, "subsection") == 0);
-    buf = "subsection 'bar' {}";
-    fail_unless(cfg_parse_buf(sec, buf) == CFG_SUCCESS);
-    fail_unless(cfg_size(sec, "subsection") == 1);
-    subsec = cfg_getnsec(sec, "subsection", 0);
-    fail_unless(subsec != 0);
-    fail_unless(strcmp(cfg_title(subsec), "bar") == 0);
-    fail_unless(cfg_getnfloat(subsec, "subsubfloat", 2) == 0);
+	sec = cfg_getnsec(cfg, "section", 1);
+	fail_unless(sec != 0);
+	fail_unless(strcmp(cfg_title(cfg_getnsec(sec, "subsection", 0)), "foo") == 0);
+	fail_unless(cfg_size(sec, "subinteger") == 14);
 
-    buf = "subsection 'baz' {}";
-    fail_unless(cfg_parse_buf(sec, buf) == CFG_SUCCESS);
-    fail_unless(cfg_gettsec(sec, "subsection", "bar") == subsec);
-    opt = cfg_getopt(sec, "subsection");
-    fail_unless(opt != 0);
-    fail_unless(cfg_gettsec(sec, "subsection", "baz") == cfg_opt_gettsec(opt, "baz"));
-    fail_unless(cfg_opt_gettsec(opt, "bar") == subsec);
-    fail_unless(cfg_opt_gettsec(opt, "foo") == 0);
-    fail_unless(cfg_gettsec(sec, "subsection", "section") == 0);
+	subsec = cfg_getsec(sec, "subsection");
+	fail_unless(cfg_size(subsec, "subsubfloat") == 3);
+	fail_unless(cfg_getnfloat(subsec, "subsubfloat", 2) == 5.6);
+	fail_unless(cfg_getnstr(subsec, "subsubstring", 0) == 0);
 
-    fail_unless(cfg_gettsec(cfg, "section", "baz") == 0);
+	sec = cfg_getnsec(cfg, "section", 0);
+	fail_unless(sec != 0);
+	fail_unless(cfg_size(sec, "subsection") == 0);
+	buf = "subsection 'bar' {}";
+	fail_unless(cfg_parse_buf(sec, buf) == CFG_SUCCESS);
+	fail_unless(cfg_size(sec, "subsection") == 1);
+	subsec = cfg_getnsec(sec, "subsection", 0);
+	fail_unless(subsec != 0);
+	fail_unless(strcmp(cfg_title(subsec), "bar") == 0);
+	fail_unless(cfg_getnfloat(subsec, "subsubfloat", 2) == 0);
+
+	buf = "subsection 'baz' {}";
+	fail_unless(cfg_parse_buf(sec, buf) == CFG_SUCCESS);
+	fail_unless(cfg_gettsec(sec, "subsection", "bar") == subsec);
+	opt = cfg_getopt(sec, "subsection");
+	fail_unless(opt != 0);
+	fail_unless(cfg_gettsec(sec, "subsection", "baz") == cfg_opt_gettsec(opt, "baz"));
+	fail_unless(cfg_opt_gettsec(opt, "bar") == subsec);
+	fail_unless(cfg_opt_gettsec(opt, "foo") == 0);
+	fail_unless(cfg_gettsec(sec, "subsection", "section") == 0);
+
+	fail_unless(cfg_gettsec(cfg, "section", "baz") == 0);
 }
 
 static void parse_buf_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_parse_buf(cfg, 0) == CFG_SUCCESS);
-    fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
+	fail_unless(cfg_parse_buf(cfg, 0) == CFG_SUCCESS);
+	fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
 
-    buf = "bool = {true, true, false, wrong}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
-    buf = "string = {foo, bar";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "bool = {true, true, false, wrong}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "string = {foo, bar";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "/* this is a comment */ bool = {true} /*// another comment */";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "/* this is a comment */ bool = {true} /*// another comment */";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 
-    buf = "/*/*/ bool = {true}//  */";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "/*/*/ bool = {true}//  */";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 
-    buf = "/////// this is a comment\nbool = {true} // another /* comment */";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "/////// this is a comment\nbool = {true} // another /* comment */";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 
-    buf = "# this is a comment\nbool = {true} # another //* comment *//";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "# this is a comment\nbool = {true} # another //* comment *//";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 
-    buf = "string={/usr/local/}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "/usr/local/") == 0);
+	buf = "string={/usr/local/}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(strcmp(cfg_getnstr(cfg, "string", 0), "/usr/local/") == 0);
 }
 
 static void nonexistent_option_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_numopts(cfg->opts) == numopts);
-    fail_unless(cfg_getopt(cfg, "nonexistent") == 0);
+	fail_unless(cfg_numopts(cfg->opts) == numopts);
+	fail_unless(cfg_getopt(cfg, "nonexistent") == 0);
 
-    buf = "section {}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getopt(cfg, "section|subnonexistent") == 0);
+	buf = "section {}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getopt(cfg, "section|subnonexistent") == 0);
 }
 
-int
-main(void)
+int main(void)
 {
-    list_setup();
+	list_setup();
 
-    list_string_test();
-    list_integer_test();
-    list_float_test();
-    list_bool_test();
-    list_section_test();
-    parse_buf_test();
-    nonexistent_option_test();
+	list_string_test();
+	list_integer_test();
+	list_float_test();
+	list_bool_test();
+	list_section_test();
+	parse_buf_test();
+	nonexistent_option_test();
 
-    list_teardown();
+	list_teardown();
 
-    return 0;
+	return 0;
 }
 
+/**
+ * Local Variables:
+ *  version-control: t
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/suite_single.c
+++ b/tests/suite_single.c
@@ -9,367 +9,354 @@ static cfg_t *cfg;
 
 int parse_ip_address(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
-    int i;
-    unsigned int e[4];
-    unsigned char *addr;
-    if (sscanf(value, "%u.%u.%u.%u", e + 0, e + 1, e + 2, e + 3) != 4)
-    {
-        /*cfg_error(cfg, "invalid IP address %s in section %s", value, cfg->name);*/
-        return 1;
-    }
-    addr = (unsigned char *)malloc(sizeof(4));
-    for (i = 0; i < 4; i++)
-    {
-        if (e[i] <= 0xff)
-        {
-            addr[i] = e[i];
-        }
-        else
-        {
-            free(addr);
-            return 1;
-        }
-    }
-    *(void **)result = (void *)addr;
-    return 0;
+	int i;
+	unsigned int e[4];
+	unsigned char *addr;
+
+	if (sscanf(value, "%u.%u.%u.%u", e + 0, e + 1, e + 2, e + 3) != 4) {
+		/*cfg_error(cfg, "invalid IP address %s in section %s", value, cfg->name); */
+		return 1;
+	}
+	addr = (unsigned char *)malloc(sizeof(4));
+	for (i = 0; i < 4; i++) {
+		if (e[i] <= 0xff) {
+			addr[i] = e[i];
+		} else {
+			free(addr);
+			return 1;
+		}
+	}
+	*(void **)result = (void *)addr;
+	return 0;
 }
 
 static unsigned char *my_ether_aton(const char *addr)
 {
-    int i;
-    static unsigned int e[6];
-    static unsigned char ec[6];
-    if(sscanf(addr, "%x:%x:%x:%x:%x:%x", &e[0], &e[1], &e[2], &e[3], &e[4], &e[5]) != 6)
-    {
-        return NULL;
-    }
-    for(i = 0; i < 6; i++)
-    {
-        if(e[i] <= 0xff)
-            ec[i] = e[i];
-        else
-            return NULL;
-    }
-    return ec;
+	int i;
+	static unsigned int e[6];
+	static unsigned char ec[6];
+
+	if (sscanf(addr, "%x:%x:%x:%x:%x:%x", &e[0], &e[1], &e[2], &e[3], &e[4], &e[5]) != 6) {
+		return NULL;
+	}
+	for (i = 0; i < 6; i++) {
+		if (e[i] <= 0xff)
+			ec[i] = e[i];
+		else
+			return NULL;
+	}
+	return ec;
 }
 
 static char *my_ether_ntoa(unsigned char *addr)
 {
-    static char buf[18];
+	static char buf[18];
 
-    sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",
-            addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
+	sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 
-    return buf;
+	return buf;
 }
 
 static char *my_inet_ntoa(unsigned char *addr)
 {
-    static char buf[16];
+	static char buf[16];
 
-    sprintf(buf, "%d.%d.%d.%d", addr[0], addr[1], addr[2], addr[3]);
+	sprintf(buf, "%d.%d.%d.%d", addr[0], addr[1], addr[2], addr[3]);
 
-    return buf;
+	return buf;
 }
 
 int parse_ether_address(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
-    unsigned char *tmp;
+	unsigned char *tmp;
 
-    tmp = my_ether_aton(value);
-    if(tmp == 0)
-    {
-        /*cfg_error(cfg, "invalid Ethernet address %s in section %s", value, cfg->name);*/
-        return 1;
-    }
-    *(void **)result = malloc(6);
-    memcpy(*(void **)result, tmp, 6);
-    return 0;
+	tmp = my_ether_aton(value);
+	if (tmp == 0) {
+		/*cfg_error(cfg, "invalid Ethernet address %s in section %s", value, cfg->name); */
+		return 1;
+	}
+	*(void **)result = malloc(6);
+	memcpy(*(void **)result, tmp, 6);
+	return 0;
 }
 
 void single_setup(void)
 {
-    static cfg_opt_t subsec_opts[] = 
-    {
-        CFG_STR("subsubstring", "subsubdefault", CFGF_NONE),
-        CFG_INT("subsubinteger", -42, CFGF_NONE),
-        CFG_FLOAT("subsubfloat", 19923.1234, CFGF_NONE),
-        CFG_BOOL("subsubbool", cfg_false, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t subsec_opts[] = {
+		CFG_STR("subsubstring", "subsubdefault", CFGF_NONE),
+		CFG_INT("subsubinteger", -42, CFGF_NONE),
+		CFG_FLOAT("subsubfloat", 19923.1234, CFGF_NONE),
+		CFG_BOOL("subsubbool", cfg_false, CFGF_NONE),
+		CFG_END()
+	};
 
-    static cfg_opt_t sec_opts[] =
-    {
-        CFG_STR("substring", "subdefault", CFGF_NONE),
-        CFG_INT("subinteger", 17, CFGF_NONE),
-        CFG_FLOAT("subfloat", 8.37, CFGF_NONE),
-        CFG_BOOL("subbool", cfg_true, CFGF_NONE),
-        CFG_SEC("subsection", subsec_opts, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t sec_opts[] = {
+		CFG_STR("substring", "subdefault", CFGF_NONE),
+		CFG_INT("subinteger", 17, CFGF_NONE),
+		CFG_FLOAT("subfloat", 8.37, CFGF_NONE),
+		CFG_BOOL("subbool", cfg_true, CFGF_NONE),
+		CFG_SEC("subsection", subsec_opts, CFGF_NONE),
+		CFG_END()
+	};
 
-    static cfg_opt_t nodef_opts[] =
-    {
-        CFG_STR("string", "defvalue", CFGF_NONE),
-        CFG_INT("int", -17, CFGF_NODEFAULT),
-        CFG_END()
-    };
+	static cfg_opt_t nodef_opts[] = {
+		CFG_STR("string", "defvalue", CFGF_NONE),
+		CFG_INT("int", -17, CFGF_NODEFAULT),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = 
-    {
-        CFG_STR("string", "default", CFGF_NONE),
-        CFG_INT("integer", 4711, CFGF_NONE),
-        CFG_FLOAT("float", 0.42, CFGF_NONE),
-        CFG_BOOL("bool", cfg_false, CFGF_NONE),
-        CFG_PTR_CB("ip-address", 0, CFGF_NONE, parse_ip_address, free),
-        CFG_PTR_CB("ethernet-address", 0, CFGF_NONE, parse_ether_address, free),
-        CFG_SEC("section", sec_opts, CFGF_NONE),
-        CFG_STR("nodefstring", "not used", CFGF_NODEFAULT),
-        CFG_SEC("nodefsec", nodef_opts, CFGF_NODEFAULT),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_STR("string", "default", CFGF_NONE),
+		CFG_INT("integer", 4711, CFGF_NONE),
+		CFG_FLOAT("float", 0.42, CFGF_NONE),
+		CFG_BOOL("bool", cfg_false, CFGF_NONE),
+		CFG_PTR_CB("ip-address", 0, CFGF_NONE, parse_ip_address, free),
+		CFG_PTR_CB("ethernet-address", 0, CFGF_NONE, parse_ether_address, free),
+		CFG_SEC("section", sec_opts, CFGF_NONE),
+		CFG_STR("nodefstring", "not used", CFGF_NODEFAULT),
+		CFG_SEC("nodefsec", nodef_opts, CFGF_NODEFAULT),
+		CFG_END()
+	};
 
-    cfg = cfg_init(opts, 0);
+	cfg = cfg_init(opts, 0);
 
-    memset(opts, 0, sizeof(opts));
-    memset(sec_opts, 0, sizeof(sec_opts));
-    memset(subsec_opts, 0, sizeof(subsec_opts));
+	memset(opts, 0, sizeof(opts));
+	memset(sec_opts, 0, sizeof(sec_opts));
+	memset(subsec_opts, 0, sizeof(subsec_opts));
 }
 
 void single_teardown(void)
 {
-    cfg_free(cfg);
+	cfg_free(cfg);
 }
 
 void single_string_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_size(cfg, "string") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "string")) == 1);
-    fail_unless(strcmp(cfg_getstr(cfg, "string"), "default") == 0);
-    fail_unless(cfg_getnstr(cfg, "string", 0) == cfg_getstr(cfg, "string"));
-    fail_unless(cfg_getnstr(cfg, "string", 1) == 0);
-    buf = "string = 'set'";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(strcmp(cfg_getstr(cfg, "string"), "set") == 0);
-    cfg_setstr(cfg, "string", "manually set");
-    fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually set") == 0);
-    buf = "multi set";
-    fail_unless(cfg_setmulti(cfg, "string", 1, &buf) == 0);
-    fail_unless(strcmp(cfg_getstr(cfg, "string"), "multi set") == 0);
+	fail_unless(cfg_size(cfg, "string") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "string")) == 1);
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "default") == 0);
+	fail_unless(cfg_getnstr(cfg, "string", 0) == cfg_getstr(cfg, "string"));
+	fail_unless(cfg_getnstr(cfg, "string", 1) == 0);
+	buf = "string = 'set'";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "set") == 0);
+	cfg_setstr(cfg, "string", "manually set");
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "manually set") == 0);
+	buf = "multi set";
+	fail_unless(cfg_setmulti(cfg, "string", 1, &buf) == 0);
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "multi set") == 0);
 }
 
 void single_integer_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_size(cfg, "integer") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "integer")) == 1);
-    fail_unless(cfg_getint(cfg, "integer") == 4711);
-    fail_unless(cfg_getnint(cfg, "integer", 0) == cfg_getint(cfg, "integer"));
-    fail_unless(cfg_getnint(cfg, "integer", 1) == 0);
-    buf = "integer = -46";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getint(cfg, "integer") == -46);
-    cfg_setint(cfg, "integer", 999999);
-    fail_unless(cfg_getint(cfg, "integer") == 999999);
-    buf = "42";
-    fail_unless(cfg_setmulti(cfg, "integer", 1, &buf) == 0);
-    fail_unless(cfg_getint(cfg, "integer") == 42);
-    buf = "ouch";
-    fail_unless(cfg_setmulti(cfg, "integer", 1, &buf) == -1);
-    fail_unless(cfg_getint(cfg, "integer") == 42);
+	fail_unless(cfg_size(cfg, "integer") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "integer")) == 1);
+	fail_unless(cfg_getint(cfg, "integer") == 4711);
+	fail_unless(cfg_getnint(cfg, "integer", 0) == cfg_getint(cfg, "integer"));
+	fail_unless(cfg_getnint(cfg, "integer", 1) == 0);
+	buf = "integer = -46";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getint(cfg, "integer") == -46);
+	cfg_setint(cfg, "integer", 999999);
+	fail_unless(cfg_getint(cfg, "integer") == 999999);
+	buf = "42";
+	fail_unless(cfg_setmulti(cfg, "integer", 1, &buf) == 0);
+	fail_unless(cfg_getint(cfg, "integer") == 42);
+	buf = "ouch";
+	fail_unless(cfg_setmulti(cfg, "integer", 1, &buf) == -1);
+	fail_unless(cfg_getint(cfg, "integer") == 42);
 }
 
 void single_float_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_size(cfg, "float") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 1);
-    fail_unless(cfg_getfloat(cfg, "float") == 0.42);
-    fail_unless(cfg_getnfloat(cfg, "float", 0) == cfg_getfloat(cfg, "float"));
-    fail_unless(cfg_getnfloat(cfg, "float", 1) == 0);
-    buf = "float = -46.777";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getfloat(cfg, "float") == -46.777);
-    cfg_setfloat(cfg, "float", 5.1234e2);
-    fail_unless(cfg_getfloat(cfg, "float") == 5.1234e2);
-    buf = "4.2";
-    fail_unless(cfg_setmulti(cfg, "float", 1, &buf) == 0);
-    fail_unless(cfg_getfloat(cfg, "float") == 4.2);
-    buf = "ouch";
-    fail_unless(cfg_setmulti(cfg, "float", 1, &buf) == -1);
-    fail_unless(cfg_getfloat(cfg, "float") == 4.2);
+	fail_unless(cfg_size(cfg, "float") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "float")) == 1);
+	fail_unless(cfg_getfloat(cfg, "float") == 0.42);
+	fail_unless(cfg_getnfloat(cfg, "float", 0) == cfg_getfloat(cfg, "float"));
+	fail_unless(cfg_getnfloat(cfg, "float", 1) == 0);
+	buf = "float = -46.777";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getfloat(cfg, "float") == -46.777);
+	cfg_setfloat(cfg, "float", 5.1234e2);
+	fail_unless(cfg_getfloat(cfg, "float") == 5.1234e2);
+	buf = "4.2";
+	fail_unless(cfg_setmulti(cfg, "float", 1, &buf) == 0);
+	fail_unless(cfg_getfloat(cfg, "float") == 4.2);
+	buf = "ouch";
+	fail_unless(cfg_setmulti(cfg, "float", 1, &buf) == -1);
+	fail_unless(cfg_getfloat(cfg, "float") == 4.2);
 }
 
 void single_bool_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_size(cfg, "bool") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 1);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+	fail_unless(cfg_size(cfg, "bool") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "bool")) == 1);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
 
-    buf = "bool = yes";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
-    buf = "bool = no";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
-    buf = "bool = true";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
-    buf = "bool = false";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
-    buf = "bool = on";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
-    buf = "bool = off";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+	buf = "bool = yes";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	buf = "bool = no";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+	buf = "bool = true";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	buf = "bool = false";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+	buf = "bool = on";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	buf = "bool = off";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
 
-    cfg_setbool(cfg, "bool", cfg_true);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
-    cfg_setbool(cfg, "bool", cfg_false);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
+	cfg_setbool(cfg, "bool", cfg_true);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	cfg_setbool(cfg, "bool", cfg_false);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_false);
 
-    buf = "true";
-    fail_unless(cfg_setmulti(cfg, "bool", 1, &buf) == 0);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
-    buf = "later";
-    fail_unless(cfg_setmulti(cfg, "bool", 1, &buf) == -1);
-    fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	buf = "true";
+	fail_unless(cfg_setmulti(cfg, "bool", 1, &buf) == 0);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
+	buf = "later";
+	fail_unless(cfg_setmulti(cfg, "bool", 1, &buf) == -1);
+	fail_unless(cfg_getbool(cfg, "bool") == cfg_true);
 }
 
 void single_section_test(void)
 {
-    char *buf;
-    cfg_t *sec, *subsec;
+	char *buf;
+	cfg_t *sec, *subsec;
 
-    fail_unless(cfg_size(cfg, "section") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "section")) == 1);
+	fail_unless(cfg_size(cfg, "section") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "section")) == 1);
 
-    fail_unless(cfg_size(cfg, "section|subsection") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "section|subsection")) == 1);
+	fail_unless(cfg_size(cfg, "section|subsection") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "section|subsection")) == 1);
 
-    fail_unless(cfg_size(cfg, "section|subsection|subsubstring") == 1);
-    fail_unless(cfg_opt_size(cfg_getopt(cfg, "section|subsection|subsubinteger")) == 1);
+	fail_unless(cfg_size(cfg, "section|subsection|subsubstring") == 1);
+	fail_unless(cfg_opt_size(cfg_getopt(cfg, "section|subsection|subsubinteger")) == 1);
 
-    fail_unless(cfg_title(cfg_getsec(cfg, "section")) == 0);
-    fail_unless(cfg_title(cfg_getsec(cfg, "section|subsection")) == 0);
-    
-    fail_unless(strcmp(cfg_getstr(cfg, "section|substring"), "subdefault") == 0);
-    sec = cfg_getsec(cfg, "section|subsection");
-    fail_unless(sec != 0);
-    fail_unless(cfg_getint(sec, "subsubinteger") == -42);
+	fail_unless(cfg_title(cfg_getsec(cfg, "section")) == 0);
+	fail_unless(cfg_title(cfg_getsec(cfg, "section|subsection")) == 0);
 
-    fail_unless(cfg_getnsec(cfg, "section", 0) == cfg_getsec(cfg, "section"));
-    fail_unless(cfg_getnsec(cfg, "section", 1) == 0);
+	fail_unless(strcmp(cfg_getstr(cfg, "section|substring"), "subdefault") == 0);
+	sec = cfg_getsec(cfg, "section|subsection");
+	fail_unless(sec != 0);
+	fail_unless(cfg_getint(sec, "subsubinteger") == -42);
 
-    sec = cfg_getsec(cfg, "section");
-    fail_unless(sec != 0);
-    subsec = cfg_getsec(sec, "subsection");
-    fail_unless(subsec != 0);
-    fail_unless(cfg_getfloat(subsec, "subsubfloat") == 19923.1234);
-    
-    buf = "section { substring = \"foo\" subsection { subsubstring = \"bar\"} }"; 
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	fail_unless(cfg_getnsec(cfg, "section", 0) == cfg_getsec(cfg, "section"));
+	fail_unless(cfg_getnsec(cfg, "section", 1) == 0);
+
+	sec = cfg_getsec(cfg, "section");
+	fail_unless(sec != 0);
+	subsec = cfg_getsec(sec, "subsection");
+	fail_unless(subsec != 0);
+	fail_unless(cfg_getfloat(subsec, "subsubfloat") == 19923.1234);
+
+	buf = "section { substring = \"foo\" subsection { subsubstring = \"bar\"} }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 }
 
 void single_ptr_test(void)
 {
-    char *buf;
-    char tmp[80];
-    char addr[] = { 0xC0, 0xA8, 0x00, 0x01, 0 }; /* 192.168.0.1 */
-    struct in_addr *ipaddr;
-    unsigned char *etheraddr, *cmpether;
+	char *buf;
+	char tmp[80];
+	char addr[] = { 0xC0, 0xA8, 0x00, 0x01, 0 };	/* 192.168.0.1 */
+	struct in_addr *ipaddr;
+	unsigned char *etheraddr, *cmpether;
 
-    fail_unless(cfg_size(cfg, "ip-address") == 0);
+	fail_unless(cfg_size(cfg, "ip-address") == 0);
 
-    /* Test valid IPv4 address */
-    snprintf(tmp, sizeof(tmp), "ip-address = %s", my_inet_ntoa(addr));
-    fail_unless(cfg_parse_buf(cfg, tmp) == CFG_SUCCESS);
-    ipaddr = cfg_getptr(cfg, "ip-address");
-    fail_unless(ipaddr != 0);
-    fail_unless(memcmp(addr, ipaddr, 4) == 0);
+	/* Test valid IPv4 address */
+	snprintf(tmp, sizeof(tmp), "ip-address = %s", my_inet_ntoa(addr));
+	fail_unless(cfg_parse_buf(cfg, tmp) == CFG_SUCCESS);
+	ipaddr = cfg_getptr(cfg, "ip-address");
+	fail_unless(ipaddr != 0);
+	fail_unless(memcmp(addr, ipaddr, 4) == 0);
 
-    /* Test invalid IPv4 address */
-    buf = "ip-address = 192.168.0.325";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	/* Test invalid IPv4 address */
+	buf = "ip-address = 192.168.0.325";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "ethernet-address = '00:03:93:d4:05:58'";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    etheraddr = cfg_getptr(cfg, "ethernet-address");
-    fail_unless(etheraddr != 0);
-    fail_unless(my_ether_ntoa(etheraddr) != 0);
-    cmpether = my_ether_aton("00:03:93:d4:05:58");
-    fail_unless(memcmp(etheraddr, cmpether, 6) == 0);
+	buf = "ethernet-address = '00:03:93:d4:05:58'";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	etheraddr = cfg_getptr(cfg, "ethernet-address");
+	fail_unless(etheraddr != 0);
+	fail_unless(my_ether_ntoa(etheraddr) != 0);
+	cmpether = my_ether_aton("00:03:93:d4:05:58");
+	fail_unless(memcmp(etheraddr, cmpether, 6) == 0);
 
-    buf = "ethernet-address = '00:03:93:d4:05'";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "ethernet-address = '00:03:93:d4:05'";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 }
 
 void parse_buf_test(void)
 {
-    char *buf;
+	char *buf;
 
-    fail_unless(cfg_parse_buf(cfg, 0) == CFG_SUCCESS);
-    fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
+	fail_unless(cfg_parse_buf(cfg, 0) == CFG_SUCCESS);
+	fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
 
-    buf = "bool = wrong";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "bool = wrong";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "string = ";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "string = ";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "option = 'value'";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "option = 'value'";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 }
 
 void nonexistent_option_test(void)
 {
-    fail_unless(cfg_getopt(cfg, "nonexistent") == 0);
-    fail_unless(cfg_getopt(cfg, "section|subnonexistent") == 0);
+	fail_unless(cfg_getopt(cfg, "nonexistent") == 0);
+	fail_unless(cfg_getopt(cfg, "section|subnonexistent") == 0);
 }
 
 void nodefault_test(void)
 {
-    char *buf;
-    cfg_t *nodefsec;
+	char *buf;
+	cfg_t *nodefsec;
 
-    fail_unless(cfg_size(cfg, "nodefstring") == 0);
-    cfg_setstr(cfg, "nodefstring", "manually set");
-    fail_unless(cfg_size(cfg, "nodefstring") == 1);
-    fail_unless(cfg_size(cfg, "nodefsec") == 0);
+	fail_unless(cfg_size(cfg, "nodefstring") == 0);
+	cfg_setstr(cfg, "nodefstring", "manually set");
+	fail_unless(cfg_size(cfg, "nodefstring") == 1);
+	fail_unless(cfg_size(cfg, "nodefsec") == 0);
 
-    buf = "nodefsec {}";    
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    nodefsec = cfg_getsec(cfg, "nodefsec");
-    fail_unless(nodefsec != 0);
-    fail_unless(cfg_size(nodefsec, "string") == 1);
-    fail_unless(cfg_size(nodefsec, "int") == 0);
+	buf = "nodefsec {}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	nodefsec = cfg_getsec(cfg, "nodefsec");
+	fail_unless(nodefsec != 0);
+	fail_unless(cfg_size(nodefsec, "string") == 1);
+	fail_unless(cfg_size(nodefsec, "int") == 0);
 }
 
-int
-main(void)
+int main(void)
 {
-    single_setup();
+	single_setup();
 
-    single_string_test();
-    single_integer_test();
-    single_float_test();
-    single_bool_test();
-    single_section_test();
-    single_ptr_test();
-    parse_buf_test();
-    nonexistent_option_test();
-    nodefault_test();
-    
-    single_teardown();
+	single_string_test();
+	single_integer_test();
+	single_float_test();
+	single_bool_test();
+	single_section_test();
+	single_ptr_test();
+	parse_buf_test();
+	nonexistent_option_test();
+	nodefault_test();
 
-    return 0;
+	single_teardown();
+
+	return 0;
 }
-

--- a/tests/suite_validate.c
+++ b/tests/suite_validate.c
@@ -13,206 +13,186 @@ static cfg_t *cfg = 0;
 
 static int parse_action(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
-    if(strcmp(value, "run") == 0)
-        *(int *)result = ACTION_RUN;
-    else if(strcmp(value, "walk") == 0)
-        *(int *)result = ACTION_WALK;
-    else if(strcmp(value, "crawl") == 0)
-        *(int *)result = ACTION_CRAWL;
-    else if(strcmp(value, "jump") == 0)
-        *(int *)result = ACTION_JUMP;
-    else
-    {
-        /* cfg_error(cfg, "Invalid action value '%s'", value); */
-        return -1;
-    }
-    return 0;
+	if (strcmp(value, "run") == 0)
+		*(int *)result = ACTION_RUN;
+	else if (strcmp(value, "walk") == 0)
+		*(int *)result = ACTION_WALK;
+	else if (strcmp(value, "crawl") == 0)
+		*(int *)result = ACTION_CRAWL;
+	else if (strcmp(value, "jump") == 0)
+		*(int *)result = ACTION_JUMP;
+	else {
+		/* cfg_error(cfg, "Invalid action value '%s'", value); */
+		return -1;
+	}
+	return 0;
 }
 
 int validate_speed(cfg_t *cfg, cfg_opt_t *opt)
 {
-    unsigned int i;
+	unsigned int i;
 
-    for(i = 0; i < cfg_opt_size(opt); i++)
-    {
-        if(cfg_opt_getnint(opt, i) <= 0)
-        {
-            /* cfg_error(cfg, "speed must be positive in section %s", cfg->name); */
-            return 1;
-        }
-    }
-    return 0;
+	for (i = 0; i < cfg_opt_size(opt); i++) {
+		if (cfg_opt_getnint(opt, i) <= 0) {
+			/* cfg_error(cfg, "speed must be positive in section %s", cfg->name); */
+			return 1;
+		}
+	}
+	return 0;
 }
 
 int validate_ip(cfg_t *cfg, cfg_opt_t *opt)
 {
-    unsigned int i, j;
+	unsigned int i, j;
 
-    for(i = 0; i < cfg_opt_size(opt); i++)
-    {
-        unsigned int v[4];
-        char *ip = cfg_opt_getnstr(opt, i);
-        if (sscanf(ip, "%u.%u.%u.%u", v + 0, v + 1, v + 2, v + 3) != 4)
-        {
-            /* cfg_error(cfg, "invalid IP address %s in section %s", ip, cfg->name); */
-            return 1;
-        }
-        for (j = 0; j < 4; j++)
-        {
-            if (v[j] > 0xff)
-            {
-                return 1;
-            }
-        }
-    }
-    return 0;
+	for (i = 0; i < cfg_opt_size(opt); i++) {
+		unsigned int v[4];
+		char *ip = cfg_opt_getnstr(opt, i);
+
+		if (sscanf(ip, "%u.%u.%u.%u", v + 0, v + 1, v + 2, v + 3) != 4) {
+			/* cfg_error(cfg, "invalid IP address %s in section %s", ip, cfg->name); */
+			return 1;
+		}
+		for (j = 0; j < 4; j++) {
+			if (v[j] > 0xff) {
+				return 1;
+			}
+		}
+	}
+	return 0;
 }
 
 int validate_action(cfg_t *cfg, cfg_opt_t *opt)
 {
-    cfg_opt_t *name_opt;
-    cfg_t *action_sec = cfg_opt_getnsec(opt, 0);
+	cfg_opt_t *name_opt;
+	cfg_t *action_sec = cfg_opt_getnsec(opt, 0);
 
-    fail_unless(action_sec != 0);
+	fail_unless(action_sec != 0);
 
-    name_opt = cfg_getopt(action_sec, "name");
+	name_opt = cfg_getopt(action_sec, "name");
 
-    fail_unless(name_opt != 0);
-    fail_unless(cfg_opt_size(name_opt) == 1);
+	fail_unless(name_opt != 0);
+	fail_unless(cfg_opt_size(name_opt) == 1);
 
-    if(cfg_opt_getnstr(name_opt, 0) == NULL)
-    {
-        /* cfg_error(cfg, "missing required option 'name' in section %s", opt->name); */
-        return 1;
-    }
-    return 0;
+	if (cfg_opt_getnstr(name_opt, 0) == NULL) {
+		/* cfg_error(cfg, "missing required option 'name' in section %s", opt->name); */
+		return 1;
+	}
+	return 0;
 }
 
 void validate_setup(void)
 {
-    cfg_opt_t *opt = 0;
+	cfg_opt_t *opt = 0;
 
-    static cfg_opt_t action_opts[] =
-    {
-        CFG_INT("speed", 0, CFGF_NONE),
-        CFG_STR("name", 0, CFGF_NONE),
-        CFG_INT("xspeed", 0, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t action_opts[] = {
+		CFG_INT("speed", 0, CFGF_NONE),
+		CFG_STR("name", 0, CFGF_NONE),
+		CFG_INT("xspeed", 0, CFGF_NONE),
+		CFG_END()
+	};
 
-    static cfg_opt_t multi_opts[] =
-    {
-        CFG_INT_LIST("speeds", 0, CFGF_NONE),
-        CFG_SEC("options", action_opts, CFGF_NONE),
-        CFG_END()
-    };
+	static cfg_opt_t multi_opts[] = {
+		CFG_INT_LIST("speeds", 0, CFGF_NONE),
+		CFG_SEC("options", action_opts, CFGF_NONE),
+		CFG_END()
+	};
 
-    cfg_opt_t opts[] = 
-    {
-        CFG_STR_LIST("ip-address", 0, CFGF_NONE),
-        CFG_INT_CB("action", ACTION_NONE, CFGF_NONE, parse_action),
-        CFG_SEC("options", action_opts, CFGF_NONE),
-        CFG_SEC("multi_options", multi_opts, CFGF_MULTI),
-        CFG_END()
-    };
+	cfg_opt_t opts[] = {
+		CFG_STR_LIST("ip-address", 0, CFGF_NONE),
+		CFG_INT_CB("action", ACTION_NONE, CFGF_NONE, parse_action),
+		CFG_SEC("options", action_opts, CFGF_NONE),
+		CFG_SEC("multi_options", multi_opts, CFGF_MULTI),
+		CFG_END()
+	};
 
-    cfg = cfg_init(opts, 0);
+	cfg = cfg_init(opts, 0);
 
-    cfg_set_validate_func(cfg, "ip-address", validate_ip);
-    fail_unless(cfg_set_validate_func(cfg, "ip-address", validate_ip) == validate_ip);
-    opt = cfg_getopt(cfg, "ip-address");
-    fail_unless(opt != 0);
-    fail_unless(opt->validcb == validate_ip);
+	cfg_set_validate_func(cfg, "ip-address", validate_ip);
+	fail_unless(cfg_set_validate_func(cfg, "ip-address", validate_ip) == validate_ip);
+	opt = cfg_getopt(cfg, "ip-address");
+	fail_unless(opt != 0);
+	fail_unless(opt->validcb == validate_ip);
 
-    cfg_set_validate_func(cfg, "options", validate_action);
-    fail_unless(cfg_set_validate_func(cfg, "options", validate_action) == validate_action);
-    opt = cfg_getopt(cfg, "options");
-    fail_unless(opt != 0);
-    fail_unless(opt->validcb == validate_action);
+	cfg_set_validate_func(cfg, "options", validate_action);
+	fail_unless(cfg_set_validate_func(cfg, "options", validate_action) == validate_action);
+	opt = cfg_getopt(cfg, "options");
+	fail_unless(opt != 0);
+	fail_unless(opt->validcb == validate_action);
 
-    cfg_set_validate_func(cfg, "options|speed", validate_speed);
-    fail_unless(cfg_set_validate_func(cfg, "options|speed", validate_speed) == validate_speed);
-    opt = cfg_getopt(cfg, "options|speed");
-    fail_unless(opt != 0);
-    fail_unless(opt->validcb == validate_speed);
+	cfg_set_validate_func(cfg, "options|speed", validate_speed);
+	fail_unless(cfg_set_validate_func(cfg, "options|speed", validate_speed) == validate_speed);
+	opt = cfg_getopt(cfg, "options|speed");
+	fail_unless(opt != 0);
+	fail_unless(opt->validcb == validate_speed);
 
-    cfg_set_validate_func(cfg, "multi_options|speeds", validate_speed);
-    fail_unless(cfg_set_validate_func(cfg, "multi_options|speeds", validate_speed) == validate_speed);
+	cfg_set_validate_func(cfg, "multi_options|speeds", validate_speed);
+	fail_unless(cfg_set_validate_func(cfg, "multi_options|speeds", validate_speed) == validate_speed);
 
-    cfg_set_validate_func(cfg, "multi_options|options|xspeed", validate_speed);
-    fail_unless(cfg_set_validate_func(cfg, "multi_options|options|xspeed", validate_speed) == validate_speed);
+	cfg_set_validate_func(cfg, "multi_options|options|xspeed", validate_speed);
+	fail_unless(cfg_set_validate_func(cfg, "multi_options|options|xspeed", validate_speed) == validate_speed);
 }
 
 void validate_teardown(void)
 {
-    cfg_free(cfg);
+	cfg_free(cfg);
 }
 
 void validate_test(void)
 {
-    char *buf;
-    unsigned int i;
+	char *buf;
+	unsigned int i;
 
-    buf = "action = wlak";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "action = wlak";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "action = walk";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "action = walk";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 
-    buf = "action = run"
-          " options { speed = 6 }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "action = run" " options { speed = 6 }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "action = jump"
-          " options { speed = 2 name = 'Joe' }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "action = jump" " options { speed = 2 name = 'Joe' }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 
-    buf = "action = crawl"
-          " options { speed = -2 name = 'Smith' }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "action = crawl" " options { speed = -2 name = 'Smith' }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "ip-address = { 0.0.0.0 , 1.2.3.4 , 192.168.0.254 , 10.0.0.255 , 20.30.40.256}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
-    buf = "ip-address = { 0.0.0.0 , 1.2.3.4 , 192.168.0.254 , 10.0.0.255 , 20.30.40.250}";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    buf = "ip-address = { 1.2.3. }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "ip-address = { 0.0.0.0 , 1.2.3.4 , 192.168.0.254 , 10.0.0.255 , 20.30.40.256}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "ip-address = { 0.0.0.0 , 1.2.3.4 , 192.168.0.254 , 10.0.0.255 , 20.30.40.250}";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "ip-address = { 1.2.3. }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "action = run"
-          " multi_options { speeds = {1, 2, 3, 4, 5} }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
-    for(i = 0; i < cfg_size(cfg, "multi_options"); i++)
-    {
-        cfg_t *multisec = cfg_getnsec(cfg, "multi_options", i);
-        cfg_opt_t *speeds_opt = cfg_getopt(multisec, "speeds");
-        fail_unless(speeds_opt != 0);
-        fail_unless(speeds_opt->validcb == validate_speed);
-    }
+	buf = "action = run" " multi_options { speeds = {1, 2, 3, 4, 5} }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	for (i = 0; i < cfg_size(cfg, "multi_options"); i++) {
+		cfg_t *multisec = cfg_getnsec(cfg, "multi_options", i);
+		cfg_opt_t *speeds_opt = cfg_getopt(multisec, "speeds");
 
-    buf = "action = run"
-          " multi_options { speeds = {1, 2, 3, -4, 5} }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+		fail_unless(speeds_opt != 0);
+		fail_unless(speeds_opt->validcb == validate_speed);
+	}
 
-    buf = "action = run"
-          " multi_options { speeds = {1, 2, 3, 4, 0} }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "action = run" " multi_options { speeds = {1, 2, 3, -4, 5} }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "action = run"
-          " multi_options { options { xspeed = 3 } }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+	buf = "action = run" " multi_options { speeds = {1, 2, 3, 4, 0} }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 
-    buf = "action = run"
-          " multi_options { options { xspeed = -3 } }";
-    fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
+	buf = "action = run" " multi_options { options { xspeed = 3 } }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
+
+	buf = "action = run" " multi_options { options { xspeed = -3 } }";
+	fail_unless(cfg_parse_buf(cfg, buf) == CFG_PARSE_ERROR);
 }
 
-int
-main(void)
+int main(void)
 {
-    validate_setup();
-    validate_test();
-    validate_teardown();
+	validate_setup();
+	validate_test();
+	validate_teardown();
 
-    return 0;
+	return 0;
 }
-


### PR DESCRIPTION
This pull request reindents the code base to Linux coding style, as proposed in issue #33,
skipping only the Windows specific code in `windows/` and `examples/wincfgtest.c`.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>