### PR TITLE
Do not use assert() for checking OS API functions

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -6,4 +6,5 @@ simple
 simple.conf.out
 test.conf.out
 ftpconf
+cli
 *.o

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -716,9 +716,8 @@ DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, c
 /* searchpath */
 
 struct cfg_searchpath_t {
-	char *dir;	     /**< directory to search */
-	cfg_searchpath_t *next;
-			     /**< next in list */
+	char *dir;	        /**< directory to search */
+	cfg_searchpath_t *next; /**< next in list */
 };
 
 /* prepend a new cfg_searchpath_t to the linked list */

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -127,12 +127,13 @@ static char *strndup(const char *s, size_t n)
 	char *r;
 
 	if (s == 0)
-		return 0;
+		return NULL;
 
 	r = malloc(n + 1);
 	assert(r);
 	strncpy(r, s, n);
 	r[n] = 0;
+
 	return r;
 }
 #endif
@@ -199,29 +200,31 @@ DLLIMPORT cfg_opt_t *cfg_getopt(cfg_t *cfg, const char *name)
 				return &sec->opts[i];
 		}
 	}
+
 	cfg_error(cfg, _("no such option '%s'"), name);
-	return 0;
+
+	return NULL;
 }
 
 DLLIMPORT const char *cfg_title(cfg_t *cfg)
 {
 	if (cfg)
 		return cfg->title;
-	return 0;
+	return NULL;
 }
 
 DLLIMPORT const char *cfg_name(cfg_t *cfg)
 {
 	if (cfg)
 		return cfg->name;
-	return 0;
+	return NULL;
 }
 
 DLLIMPORT const char *cfg_opt_name(cfg_opt_t *opt)
 {
 	if (opt)
 		return opt->name;
-	return 0;
+	return NULL;
 }
 
 DLLIMPORT unsigned int cfg_opt_size(cfg_opt_t *opt)
@@ -239,12 +242,13 @@ DLLIMPORT unsigned int cfg_size(cfg_t *cfg, const char *name)
 DLLIMPORT signed long cfg_opt_getnint(cfg_opt_t *opt, unsigned int index)
 {
 	assert(opt && opt->type == CFGT_INT);
+
 	if (opt->values && index < opt->nvalues)
 		return opt->values[index]->number;
-	else if (opt->simple_value.number)
+	if (opt->simple_value.number)
 		return *opt->simple_value.number;
-	else
-		return 0;
+
+	return 0;
 }
 
 DLLIMPORT signed long cfg_getnint(cfg_t *cfg, const char *name, unsigned int index)
@@ -260,12 +264,13 @@ DLLIMPORT signed long cfg_getint(cfg_t *cfg, const char *name)
 DLLIMPORT double cfg_opt_getnfloat(cfg_opt_t *opt, unsigned int index)
 {
 	assert(opt && opt->type == CFGT_FLOAT);
+
 	if (opt->values && index < opt->nvalues)
 		return opt->values[index]->fpnumber;
-	else if (opt->simple_value.fpnumber)
+	if (opt->simple_value.fpnumber)
 		return *opt->simple_value.fpnumber;
-	else
-		return 0;
+
+	return 0;
 }
 
 DLLIMPORT double cfg_getnfloat(cfg_t *cfg, const char *name, unsigned int index)
@@ -281,12 +286,13 @@ DLLIMPORT double cfg_getfloat(cfg_t *cfg, const char *name)
 DLLIMPORT cfg_bool_t cfg_opt_getnbool(cfg_opt_t *opt, unsigned int index)
 {
 	assert(opt && opt->type == CFGT_BOOL);
+
 	if (opt->values && index < opt->nvalues)
 		return opt->values[index]->boolean;
-	else if (opt->simple_value.boolean)
+	if (opt->simple_value.boolean)
 		return *opt->simple_value.boolean;
-	else
-		return cfg_false;
+
+	return cfg_false;
 }
 
 DLLIMPORT cfg_bool_t cfg_getnbool(cfg_t *cfg, const char *name, unsigned int index)
@@ -302,12 +308,13 @@ DLLIMPORT cfg_bool_t cfg_getbool(cfg_t *cfg, const char *name)
 DLLIMPORT char *cfg_opt_getnstr(cfg_opt_t *opt, unsigned int index)
 {
 	assert(opt && opt->type == CFGT_STR);
+
 	if (opt->values && index < opt->nvalues)
 		return opt->values[index]->string;
-	else if (opt->simple_value.string)
+	if (opt->simple_value.string)
 		return *opt->simple_value.string;
-	else
-		return 0;
+
+	return NULL;
 }
 
 DLLIMPORT char *cfg_getnstr(cfg_t *cfg, const char *name, unsigned int index)
@@ -323,12 +330,13 @@ DLLIMPORT char *cfg_getstr(cfg_t *cfg, const char *name)
 DLLIMPORT void *cfg_opt_getnptr(cfg_opt_t *opt, unsigned int index)
 {
 	assert(opt && opt->type == CFGT_PTR);
+
 	if (opt->values && index < opt->nvalues)
 		return opt->values[index]->ptr;
-	else if (opt->simple_value.ptr)
+	if (opt->simple_value.ptr)
 		return *opt->simple_value.ptr;
-	else
-		return 0;
+
+	return NULL;
 }
 
 DLLIMPORT void *cfg_getnptr(cfg_t *cfg, const char *name, unsigned int index)
@@ -344,9 +352,11 @@ DLLIMPORT void *cfg_getptr(cfg_t *cfg, const char *name)
 DLLIMPORT cfg_t *cfg_opt_getnsec(cfg_opt_t *opt, unsigned int index)
 {
 	assert(opt && opt->type == CFGT_SEC);
+
 	if (opt->values && index < opt->nvalues)
 		return opt->values[index]->section;
-	return 0;
+
+	return NULL;
 }
 
 DLLIMPORT cfg_t *cfg_getnsec(cfg_t *cfg, const char *name, unsigned int index)
@@ -360,7 +370,8 @@ DLLIMPORT cfg_t *cfg_opt_gettsec(cfg_opt_t *opt, const char *title)
 
 	assert(opt && title);
 	if (!is_set(CFGF_TITLE, opt->flags))
-		return 0;
+		return NULL;
+
 	n = cfg_opt_size(opt);
 	for (i = 0; i < n; i++) {
 		cfg_t *sec = cfg_opt_getnsec(opt, i);
@@ -374,7 +385,8 @@ DLLIMPORT cfg_t *cfg_opt_gettsec(cfg_opt_t *opt, const char *title)
 				return sec;
 		}
 	}
-	return 0;
+
+	return NULL;
 }
 
 DLLIMPORT cfg_t *cfg_gettsec(cfg_t *cfg, const char *name, const char *title)
@@ -432,8 +444,9 @@ DLLIMPORT int cfg_parse_boolean(const char *s)
 {
 	if (strcasecmp(s, "true") == 0 || strcasecmp(s, "on") == 0 || strcasecmp(s, "yes") == 0)
 		return 1;
-	else if (strcasecmp(s, "false") == 0 || strcasecmp(s, "off") == 0 || strcasecmp(s, "no") == 0)
+	if (strcasecmp(s, "false") == 0 || strcasecmp(s, "off") == 0 || strcasecmp(s, "no") == 0)
 		return 0;
+
 	return -1;
 }
 
@@ -528,7 +541,7 @@ static void cfg_init_defaults(cfg_t *cfg)
 
 DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 {
-	cfg_value_t *val = 0;
+	cfg_value_t *val = NULL;
 	int b;
 	const char *s;
 	double f;
@@ -548,7 +561,8 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		}
 
 		if (opt->nvalues == 0 || is_set(CFGF_MULTI, opt->flags) || is_set(CFGF_LIST, opt->flags)) {
-			val = 0;
+			val = NULL;
+
 			if (opt->type == CFGT_SEC && is_set(CFGF_TITLE, opt->flags)) {
 				unsigned int i;
 
@@ -570,9 +584,10 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 							val = opt->values[i];
 					}
 				}
+
 				if (val && is_set(CFGF_NO_TITLE_DUPES, opt->flags)) {
 					cfg_error(cfg, _("found duplicate title '%s'"), value);
-					return 0;
+					return NULL;
 				}
 			}
 			if (val == NULL)
@@ -585,16 +600,16 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 	case CFGT_INT:
 		if (opt->parsecb) {
 			if ((*opt->parsecb) (cfg, opt, value, &i) != 0)
-				return 0;
+				return NULL;
 		} else {
 			i = strtol(value, &endptr, 0);
 			if (*endptr != '\0') {
 				cfg_error(cfg, _("invalid integer value for option '%s'"), opt->name);
-				return 0;
+				return NULL;
 			}
 			if (errno == ERANGE) {
 				cfg_error(cfg, _("integer value for option '%s' is out of range"), opt->name);
-				return 0;
+				return NULL;
 			}
 		}
 		val->number = i;
@@ -603,16 +618,16 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 	case CFGT_FLOAT:
 		if (opt->parsecb) {
 			if ((*opt->parsecb) (cfg, opt, value, &f) != 0)
-				return 0;
+				return NULL;
 		} else {
 			f = strtod(value, &endptr);
 			if (*endptr != '\0') {
 				cfg_error(cfg, _("invalid floating point value for option '%s'"), opt->name);
-				return 0;
+				return NULL;
 			}
 			if (errno == ERANGE) {
 				cfg_error(cfg, _("floating point value for option '%s' is out of range"), opt->name);
-				return 0;
+				return NULL;
 			}
 		}
 		val->fpnumber = f;
@@ -622,10 +637,11 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		if (opt->parsecb) {
 			s = 0;
 			if ((*opt->parsecb) (cfg, opt, value, &s) != 0)
-				return 0;
+				return NULL;
 		} else {
 			s = value;
 		}
+
 		free(val->string);
 		val->string = strdup(s);
 		break;
@@ -652,12 +668,12 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 	case CFGT_BOOL:
 		if (opt->parsecb) {
 			if ((*opt->parsecb) (cfg, opt, value, &b) != 0)
-				return 0;
+				return NULL;
 		} else {
 			b = cfg_parse_boolean(value);
 			if (b == -1) {
 				cfg_error(cfg, _("invalid boolean value for option '%s'"), opt->name);
-				return 0;
+				return NULL;
 			}
 		}
 		val->boolean = (cfg_bool_t)b;
@@ -666,7 +682,7 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 	case CFGT_PTR:
 		assert(opt->parsecb);
 		if ((*opt->parsecb) (cfg, opt, value, &p) != 0)
-			return 0;
+			return NULL;
 		val->ptr = p;
 		break;
 
@@ -675,6 +691,7 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		assert(0);
 		break;
 	}
+
 	return val;
 }
 
@@ -693,14 +710,17 @@ DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues,
 	for (i = 0; i < nvalues; i++) {
 		if (cfg_setopt(cfg, opt, values[i]))
 			continue;
+
 		/* ouch, revert */
 		cfg_free_value(opt);
 		opt->nvalues = old.nvalues;
 		opt->values = old.values;
+
 		return -1;
 	}
 
 	cfg_free_value(&old);
+
 	return 0;
 }
 
@@ -1036,6 +1056,7 @@ DLLIMPORT int cfg_parse_fp(cfg_t *cfg, FILE *fp)
 	cfg_scan_fp_end();
 	if (ret == STATE_ERROR)
 		return CFG_PARSE_ERROR;
+
 	return CFG_SUCCESS;
 }
 
@@ -1207,12 +1228,13 @@ DLLIMPORT char *cfg_tilde_expand(const char *filename)
 #endif
 	if (!expanded)
 		expanded = strdup(filename);
+
 	return expanded;
 }
 
 DLLIMPORT void cfg_free_value(cfg_opt_t *opt)
 {
-	if (opt == 0)
+	if (!opt)
 		return;
 
 	if (opt->values) {
@@ -1286,6 +1308,7 @@ DLLIMPORT int cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **arg
 		cfg_error(cfg, _("wrong number of arguments to cfg_include()"));
 		return 1;
 	}
+
 	return cfg_lexer_include(cfg, argv[0]);
 }
 
@@ -1308,6 +1331,7 @@ static cfg_value_t *cfg_opt_getval(cfg_opt_t *opt, unsigned int index)
 		else
 			val = opt->values[index];
 	}
+
 	return val;
 }
 
@@ -1452,13 +1476,14 @@ DLLIMPORT void cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index)
 	n = cfg_opt_size(opt);
 	if (index >= n)
 		return;
+
 	val = cfg_opt_getval(opt, index);
 	if (index + 1 != n) {
 		/* not removing last, move the tail */
 		memmove(&opt->values[index], &opt->values[index + 1], sizeof(opt->values[index]) * (n - index - 1));
 	}
 	--opt->nvalues;
-	val->section->path = 0;
+
 	cfg_free(val->section);
 	free(val);
 }
@@ -1480,6 +1505,7 @@ DLLIMPORT void cfg_opt_rmtsec(cfg_opt_t *opt, const char *title)
 	assert(opt && title);
 	if (!is_set(CFGF_TITLE, opt->flags))
 		return;
+
 	n = cfg_opt_size(opt);
 	for (i = 0; i < n; i++) {
 		cfg_t *sec = cfg_opt_getnsec(opt, i);
@@ -1495,6 +1521,7 @@ DLLIMPORT void cfg_opt_rmtsec(cfg_opt_t *opt, const char *title)
 	}
 	if (i == n)
 		return;
+
 	cfg_opt_rmnsec(opt, i);
 }
 
@@ -1508,6 +1535,7 @@ DLLIMPORT void cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index, FILE *fp)
 	const char *str;
 
 	assert(opt && fp);
+
 	switch (opt->type) {
 	case CFGT_INT:
 		fprintf(fp, "%ld", cfg_opt_getnint(opt, index));
@@ -1636,6 +1664,7 @@ DLLIMPORT cfg_print_func_t cfg_opt_set_print_func(cfg_opt_t *opt, cfg_print_func
 	cfg_print_func_t oldpf;
 
 	assert(opt);
+
 	oldpf = opt->pf;
 	opt->pf = pf;
 
@@ -1662,28 +1691,30 @@ static cfg_opt_t *cfg_getopt_array(cfg_opt_t *rootopts, int cfg_flags, const cha
 		if (name[len] == 0 /*len == strlen(name) */ )
 			/* no more subsections */
 			break;
+
 		if (len) {
 			cfg_opt_t *secopt;
 
 			secname = strndup(name, len);
 			secopt = cfg_getopt_array(opts, cfg_flags, secname);
 			free(secname);
-			if (secopt == 0) {
+			if (!secopt) {
 				/*fprintf(stderr, "section not found\n"); */
-				return 0;
+				return NULL;
 			}
 			if (secopt->type != CFGT_SEC) {
 				/*fprintf(stderr, "not a section!\n"); */
-				return 0;
+				return NULL;
 			}
 
-			if (!is_set(CFGF_MULTI, secopt->flags) && (seccfg = cfg_opt_getnsec(secopt, 0)) != 0) {
+			if (!is_set(CFGF_MULTI, secopt->flags) && (seccfg = cfg_opt_getnsec(secopt, 0)) != 0)
 				opts = seccfg->opts;
-			} else
+			else
 				opts = secopt->subopts;
-			if (opts == 0) {
+
+			if (!opts) {
 				/*fprintf(stderr, "section have no subopts!?\n"); */
-				return 0;
+				return NULL;
 			}
 		}
 		name += len;
@@ -1699,7 +1730,8 @@ static cfg_opt_t *cfg_getopt_array(cfg_opt_t *rootopts, int cfg_flags, const cha
 				return &opts[i];
 		}
 	}
-	return 0;
+
+	return NULL;
 }
 
 DLLIMPORT cfg_validate_callback_t cfg_set_validate_func(cfg_t *cfg, const char *name, cfg_validate_callback_t vf)

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -128,7 +128,7 @@ static char *strndup(const char *s, size_t n)
 {
 	char *r;
 
-	if (s == 0)
+	if (!s)
 		return NULL;
 
 	r = malloc(n + 1);
@@ -188,7 +188,7 @@ DLLIMPORT cfg_opt_t *cfg_getopt(cfg_t *cfg, const char *name)
 				return NULL;
 
 			sec = cfg_getsec(sec, secname);
-			if (sec == 0) {
+			if (!sec) {
 				cfg_error(cfg, _("no such option '%s'"), secname);
 				free(secname);
 				return NULL;
@@ -807,6 +807,7 @@ DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, c
 
 	if (!opt)
 		return -1;
+
 	return cfg_opt_setmulti(cfg, opt, nvalues, values);
 }
 
@@ -941,7 +942,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				return STATE_ERROR;
 			}
 			opt = cfg_getopt(cfg, cfg_yylval);
-			if (opt == 0) {
+			if (!opt) {
 				if (cfg->flags & CFGF_IGNORE_UNKNOWN)
 					opt = cfg_getopt(cfg, "__unknown");
 				if (opt == 0)
@@ -1462,7 +1463,8 @@ DLLIMPORT void cfg_opt_setnint(cfg_opt_t *opt, long int value, unsigned int inde
 
 	assert(opt && opt->type == CFGT_INT);
 	val = cfg_opt_getval(opt, index);
-	val->number = value;
+	if (val)
+		val->number = value;
 }
 
 DLLIMPORT void cfg_setnint(cfg_t *cfg, const char *name, long int value, unsigned int index)
@@ -1481,7 +1483,8 @@ DLLIMPORT void cfg_opt_setnfloat(cfg_opt_t *opt, double value, unsigned int inde
 
 	assert(opt && opt->type == CFGT_FLOAT);
 	val = cfg_opt_getval(opt, index);
-	val->fpnumber = value;
+	if (val)
+		val->fpnumber = value;
 }
 
 DLLIMPORT void cfg_setnfloat(cfg_t *cfg, const char *name, double value, unsigned int index)
@@ -1500,7 +1503,8 @@ DLLIMPORT void cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value, unsigned int i
 
 	assert(opt && opt->type == CFGT_BOOL);
 	val = cfg_opt_getval(opt, index);
-	val->boolean = value;
+	if (val)
+		val->boolean = value;
 }
 
 DLLIMPORT void cfg_setnbool(cfg_t *cfg, const char *name, cfg_bool_t value, unsigned int index)
@@ -1520,6 +1524,11 @@ DLLIMPORT void cfg_opt_setnstr(cfg_opt_t *opt, const char *value, unsigned int i
 
 	assert(opt && opt->type == CFGT_STR);
 	val = cfg_opt_getval(opt, index);
+	if (!val) {
+		errno = ENOENT;
+		return;
+	}
+
 	if (val->string)
 		oldstr = val->string;
 
@@ -1612,6 +1621,11 @@ DLLIMPORT void cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index)
 		return;
 
 	val = cfg_opt_getval(opt, index);
+	if (!val) {
+		errno = ENOENT;
+		return;
+	}
+
 	if (index + 1 != n) {
 		/* not removing last, move the tail */
 		memmove(&opt->values[index], &opt->values[index + 1], sizeof(opt->values[index]) * (n - index - 1));

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -92,8 +92,9 @@ typedef enum cfg_type_t cfg_type_t;
 #define CFGF_DEFINIT 128
 #define CFGF_IGNORE_UNKNOWN 256 /**< ignore unknown options in configuration files */
 
-/** Return codes from cfg_parse(). */
-#define CFG_SUCCESS 0
+/** Return codes from cfg_parse(), cfg_parse_boolean(), and cfg_set*() functions. */
+#define CFG_SUCCESS     0
+#define CFG_FAIL       -1
 #define CFG_FILE_ERROR -1
 #define CFG_PARSE_ERROR 1
 
@@ -613,6 +614,8 @@ DLLIMPORT int __export cfg_parse(cfg_t *cfg, const char *filename);
  * @param fp An open file stream.
  *
  * @see cfg_parse()
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
 DLLIMPORT int __export cfg_parse_fp(cfg_t *cfg, FILE *fp);
 
@@ -623,6 +626,8 @@ DLLIMPORT int __export cfg_parse_fp(cfg_t *cfg, FILE *fp);
  * @param buf A zero-terminated string with configuration directives.
  *
  * @see cfg_parse()
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
 DLLIMPORT int __export cfg_parse_buf(cfg_t *cfg, const char *buf);
 
@@ -630,13 +635,17 @@ DLLIMPORT int __export cfg_parse_buf(cfg_t *cfg, const char *buf);
  * the values are freed, not the option itself (it is freed by cfg_free()).
  *
  * @see cfg_free()
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_free_value(cfg_opt_t *opt);
+DLLIMPORT int __export cfg_free_value(cfg_opt_t *opt);
 
 /** Free a cfg_t context. All memory allocated by the cfg_t context
  * structure are freed, and can't be used in any further cfg_* calls.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_free(cfg_t *cfg);
+DLLIMPORT int __export cfg_free(cfg_t *cfg);
 
 /** Install a user-defined error reporting function.
  * @return The old error reporting function is returned.
@@ -910,8 +919,10 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_setnint(cfg_opt_t *opt, long int value, unsigned int index);
+DLLIMPORT int __export cfg_opt_setnint(cfg_opt_t *opt, long int value, unsigned int index);
 
 /** Set the value of an integer option given its name.
  *
@@ -919,8 +930,10 @@ DLLIMPORT void __export cfg_opt_setnint(cfg_opt_t *opt, long int value, unsigned
  * @param name The name of the option.
  * @param value The value to set. If the option is a list (the CFGF_LIST flag
  * is set), only the first value (with index 0) is set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setint(cfg_t *cfg, const char *name, long int value);
+DLLIMPORT int __export cfg_setint(cfg_t *cfg, const char *name, long int value);
 
 /** Set a value of an integer option given its name and index.
  *
@@ -930,8 +943,10 @@ DLLIMPORT void __export cfg_setint(cfg_t *cfg, const char *name, long int value)
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setnint(cfg_t *cfg, const char *name, long int value, unsigned int index);
+DLLIMPORT int __export cfg_setnint(cfg_t *cfg, const char *name, long int value, unsigned int index);
 
 /** Set a value of a floating point option.
  *
@@ -940,8 +955,10 @@ DLLIMPORT void __export cfg_setnint(cfg_t *cfg, const char *name, long int value
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_setnfloat(cfg_opt_t *opt, double value, unsigned int index);
+DLLIMPORT int __export cfg_opt_setnfloat(cfg_opt_t *opt, double value, unsigned int index);
 
 /** Set the value of a floating point option given its name.
  *
@@ -949,8 +966,10 @@ DLLIMPORT void __export cfg_opt_setnfloat(cfg_opt_t *opt, double value, unsigned
  * @param name The name of the option.
  * @param value The value to set. If the option is a list (the CFGF_LIST flag
  * is set), only the first value (with index 0) is set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setfloat(cfg_t *cfg, const char *name, double value);
+DLLIMPORT int __export cfg_setfloat(cfg_t *cfg, const char *name, double value);
 
 /** Set a value of a floating point option given its name and index.
  *
@@ -960,8 +979,10 @@ DLLIMPORT void __export cfg_setfloat(cfg_t *cfg, const char *name, double value)
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setnfloat(cfg_t *cfg, const char *name, double value, unsigned int index);
+DLLIMPORT int __export cfg_setnfloat(cfg_t *cfg, const char *name, double value, unsigned int index);
 
 /** Set a value of a boolean option.
  *
@@ -970,8 +991,10 @@ DLLIMPORT void __export cfg_setnfloat(cfg_t *cfg, const char *name, double value
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value, unsigned int index);
+DLLIMPORT int __export cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value, unsigned int index);
 
 /** Set the value of a boolean option given its name.
  *
@@ -979,8 +1002,10 @@ DLLIMPORT void __export cfg_opt_setnbool(cfg_opt_t *opt, cfg_bool_t value, unsig
  * @param name The name of the option.
  * @param value The value to set. If the option is a list (the CFGF_LIST flag
  * is set), only the first value (with index 0) is set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setbool(cfg_t *cfg, const char *name, cfg_bool_t value);
+DLLIMPORT int __export cfg_setbool(cfg_t *cfg, const char *name, cfg_bool_t value);
 
 /** Set a value of a boolean option given its name and index.
  *
@@ -990,8 +1015,10 @@ DLLIMPORT void __export cfg_setbool(cfg_t *cfg, const char *name, cfg_bool_t val
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setnbool(cfg_t *cfg, const char *name, cfg_bool_t value, unsigned int index);
+DLLIMPORT int __export cfg_setnbool(cfg_t *cfg, const char *name, cfg_bool_t value, unsigned int index);
 
 /** Set a value of a string option.
  *
@@ -1001,8 +1028,10 @@ DLLIMPORT void __export cfg_setnbool(cfg_t *cfg, const char *name, cfg_bool_t va
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_setnstr(cfg_opt_t *opt, const char *value, unsigned int index);
+DLLIMPORT int __export cfg_opt_setnstr(cfg_opt_t *opt, const char *value, unsigned int index);
 
 /** Set the value of a string option given its name.
  *
@@ -1011,8 +1040,10 @@ DLLIMPORT void __export cfg_opt_setnstr(cfg_opt_t *opt, const char *value, unsig
  * @param value The value to set. Memory for the string is allocated and the
  * value is copied. Any previous string value is freed. If the option is a list
  * (the CFGF_LIST flag is set), only the first value (with index 0) is set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setstr(cfg_t *cfg, const char *name, const char *value);
+DLLIMPORT int __export cfg_setstr(cfg_t *cfg, const char *name, const char *value);
 
 /** Set a value of a boolean option given its name and index.
  *
@@ -1023,8 +1054,10 @@ DLLIMPORT void __export cfg_setstr(cfg_t *cfg, const char *name, const char *val
  * @param index The index in the option value array that should be
  * modified. It is an error to set values with indices larger than 0
  * for options without the CFGF_LIST flag set.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setnstr(cfg_t *cfg, const char *name, const char *value, unsigned int index);
+DLLIMPORT int __export cfg_setnstr(cfg_t *cfg, const char *name, const char *value, unsigned int index);
 
 /** Set values for a list option. All existing values are replaced
  * with the new ones.
@@ -1035,8 +1068,10 @@ DLLIMPORT void __export cfg_setnstr(cfg_t *cfg, const char *name, const char *va
  * @param ... The values to set, the type must match the type of the
  * option and the number of values must be equal to the nvalues
  * parameter.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_setlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...);
+DLLIMPORT int __export cfg_setlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...);
 
 DLLIMPORT int __export cfg_numopts(cfg_opt_t *opts);
 
@@ -1049,8 +1084,10 @@ DLLIMPORT int __export cfg_numopts(cfg_opt_t *opts);
  * @param ... The values to add, the type must match the type of the
  * option and the number of values must be equal to the nvalues
  * parameter.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...);
+DLLIMPORT int __export cfg_addlist(cfg_t *cfg, const char *name, unsigned int nvalues, ...);
 
 /** Set an option (create an instance of an option).
  *
@@ -1059,8 +1096,7 @@ DLLIMPORT void __export cfg_addlist(cfg_t *cfg, const char *name, unsigned int n
  * @param nvalues The number of values to set for the option.
  * @param values The value(s) for the option.
  *
- * @return Returns 0 if the option values where set correctly,
- * or -1 if an error occurred.
+ * @return POSIX OK(0), or non-zero on failure.
  */
 DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues, char **values);
 
@@ -1071,8 +1107,7 @@ DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues,
  * @param nvalues The number of values to set for the option.
  * @param values The value(s) for the option.
  *
- * @return Returns 0 if the option values where set correctly,
- * or -1 if an error occurred.
+ * @return POSIX OK(0), or non-zero on failure.
  */
 DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, char **values);
 
@@ -1080,23 +1115,29 @@ DLLIMPORT int cfg_setmulti(cfg_t *cfg, const char *name, unsigned int nvalues, c
  * @param opt The option structure (eg, as returned from cfg_getopt())
  * @param index Index of the section to remove. Zero based.
  * @see cfg_rmnsec
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index);
+DLLIMPORT int __export cfg_opt_rmnsec(cfg_opt_t *opt, unsigned int index);
 
 /** Indexed version of cfg_rmsec(), used for CFGF_MULTI sections.
  * @param cfg The configuration file context.
  * @param name The name of the section.
  * @param index Index of the section to remove. Zero based.
  * @see cfg_rmsec
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_rmnsec(cfg_t *cfg, const char *name, unsigned int index);
+DLLIMPORT int __export cfg_rmnsec(cfg_t *cfg, const char *name, unsigned int index);
 
 /** Removes and frees a config section. This is the same as
  * calling cfg_rmnsec with index 0.
  * @param cfg The configuration file context.
  * @param name The name of the section.
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_rmsec(cfg_t *cfg, const char *name);
+DLLIMPORT int __export cfg_rmsec(cfg_t *cfg, const char *name);
 
 /** Removes and frees a config section, given a cfg_opt_t pointer
  * and the title.
@@ -1104,8 +1145,10 @@ DLLIMPORT void __export cfg_rmsec(cfg_t *cfg, const char *name);
  * @param title The title of this section. The CFGF_TITLE flag must
  * have been set for this option.
  * @see cfg_rmtsec
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_rmtsec(cfg_opt_t *opt, const char *title);
+DLLIMPORT int __export cfg_opt_rmtsec(cfg_opt_t *opt, const char *title);
 
 /** Removes and frees a section given the title, used for section with the
  * CFGF_TITLE flag set.
@@ -1115,8 +1158,10 @@ DLLIMPORT void __export cfg_opt_rmtsec(cfg_opt_t *opt, const char *title);
  * @param title The title of this section. The CFGF_TITLE flag must
  * have been set for this option.
  * @see cfg_rmsec
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_rmtsec(cfg_t *cfg, const char *name, const char *title);
+DLLIMPORT int __export cfg_rmtsec(cfg_t *cfg, const char *name, const char *title);
 
 /** Default value print function.
  *
@@ -1129,14 +1174,18 @@ DLLIMPORT void __export cfg_rmtsec(cfg_t *cfg, const char *name, const char *tit
  * @param fp File stream to print to.
  *
  * @see cfg_print, cfg_opt_print
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index, FILE *fp);
+DLLIMPORT int __export cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index, FILE *fp);
 
 /** Print an option and its value to a file.
  * Same as cfg_opt_print, but with the indentation level specified.
  * @see cfg_opt_print
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent);
+DLLIMPORT int __export cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent);
 
 /** Print an option and its value to a file.
  *
@@ -1147,14 +1196,18 @@ DLLIMPORT void __export cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int inden
  * @param fp File stream to print to.
  *
  * @see cfg_print_func_t
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_opt_print(cfg_opt_t *opt, FILE *fp);
+DLLIMPORT int __export cfg_opt_print(cfg_opt_t *opt, FILE *fp);
 
 /** Print the options and values to a file.
  * Same as cfg_print, but with the indentation level specified.
  * @see cfg_print
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_print_indent(cfg_t *cfg, FILE *fp, int indent);
+DLLIMPORT int __export cfg_print_indent(cfg_t *cfg, FILE *fp, int indent);
 
 /** Print the options and values to a file.
  *
@@ -1168,8 +1221,10 @@ DLLIMPORT void __export cfg_print_indent(cfg_t *cfg, FILE *fp, int indent);
  * @param fp File stream to print to, use stdout to print to the screen.
  *
  * @see cfg_print_func_t, cfg_set_print_func
+ *
+ * @return POSIX OK(0), or non-zero on failure.
  */
-DLLIMPORT void __export cfg_print(cfg_t *cfg, FILE *fp);
+DLLIMPORT int __export cfg_print(cfg_t *cfg, FILE *fp);
 
 /** Set a print callback function for an option.
  *

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -288,10 +288,10 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
     char *xfilename;
 
     if (cfg_include_stack_ptr >= MAX_INCLUDE_DEPTH) 
-      {
+    {
         cfg_error(cfg, _("includes nested too deeply"));
-        return 1;
-      }
+        return CFG_PARSE_ERROR;
+    }
 
     cfg_include_stack[cfg_include_stack_ptr].state = YY_CURRENT_BUFFER;
     cfg_include_stack[cfg_include_stack_ptr].filename = cfg->filename;
@@ -303,7 +303,7 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
 	if ((xfilename = cfg_searchpath(cfg->path, filename)) == NULL)
 	{
 	    cfg_error(cfg, "%s: Not found on searchpath", xfilename);
-	    return 1;
+	    return CFG_PARSE_ERROR;
 	}
     }
     else xfilename = cfg_tilde_expand(filename);
@@ -314,7 +314,7 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
       {
         cfg_error(cfg, "%s: %s", xfilename, strerror(errno));
         free(xfilename);
-        return 1;
+        return CFG_PARSE_ERROR;
       }
 
     cfg->filename = xfilename;
@@ -322,7 +322,7 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
 
     yy_switch_to_buffer(yy_create_buffer(cfg_yyin, YY_BUF_SIZE));
 
-    return 0;
+    return CFG_SUCCESS;
 }
 
 /* write a character to the quoted string buffer, and reallocate as

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,8 +1,11 @@
 .deps
 .libs
 check_confuse
-malloc.log
+env
+ignore_parm
 list_plus_syntax
+malloc.log
+section_remove
 section_title_dupes
 suite_dup
 suite_func
@@ -14,3 +17,5 @@ quote_before_print
 single_title_sections
 searchpath
 *.o
+*.log
+*.trs


### PR DESCRIPTION
This pull request is a mix of `.gitignore` updates, doc comment fixes from
previous pull request, whitespace and readability cleanup.  But the most
important patch is the last one which replaces the use of `assert()` as a
means of verifying OS memory allocation with NULL returns.
