### PR TITLE
Fix issue #46: cfg_init() unconditionally calls setlocale()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@ Special thanks in this release goes out to Frank Hunleth, Peter Rosin
 and David Grayson for their tireless efforts in helping improve this
 library!
 
+**Note:** libConfuse no longer calls `setlocale()` for `LC_MESSAGES` and
+  `LC_CTYPE`.  See the documentation for `cfg_init()` for details.
+
 ### Changes
 
 * Support for handling unknown options.  The idea is to provide future
@@ -26,7 +29,10 @@ library!
 * Support for Travis-CI and Coverity Scan, by Joachim Nilsson.
 * Use `autoreconf` in `autogen.sh` instead of calling tools separtely.
 * Powershell script for AppVeyor CI to build libConfuse with MSYS2
-  by David Grayson,
+  by David Grayson.
+* Removed calls to `setlocale()` intended to localize messages, with
+  `LC_MESSAGES`, and region specific types, with `LC_CTYPE`.  This is
+  now the responsibility of the user of the library.
 
 ### Fixes
 

--- a/examples/ftpconf.c
+++ b/examples/ftpconf.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <locale.h>
 #include <confuse.h>
 
 /* valid values for the auto-create-bookmark option */
@@ -103,11 +104,16 @@ cfg_t *parse_conf(const char *filename)
 	return cfg;
 }
 
+/* Parse the file ftp.conf and print the parsed configuration options */
 int main(int argc, char **argv)
 {
-	cfg_t *cfg = parse_conf(argc > 1 ? argv[1] : "ftp.conf");
+	cfg_t *cfg;
 
-	/* print the parsed configuration options */
+	/* Localize messages & types according to environment, since v2.9 */
+	setlocale(LC_MESSAGES, "");
+	setlocale(LC_CTYPE, "");
+
+	cfg = parse_conf(argc > 1 ? argv[1] : "ftp.conf");
 	if (cfg) {
 		unsigned int i;
 

--- a/examples/reread.c
+++ b/examples/reread.c
@@ -1,7 +1,8 @@
-#include "confuse.h"
 #include <string.h>
 #include <signal.h>
 #include <unistd.h>
+#include <locale.h>
+#include "confuse.h"
 
 cfg_t *cfg = 0;
 const char *config_filename = "./reread.conf";
@@ -45,6 +46,10 @@ void usr1handler(int sig)
 int main(void)
 {
 	unsigned int i;
+
+	/* Localize messages & types according to environment, since v2.9 */
+	setlocale(LC_MESSAGES, "");
+	setlocale(LC_CTYPE, "");
 
 	read_config();
 	signal(SIGHUP, sighandler);

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <string.h>
 #include <stdlib.h>
+#include <locale.h>
 #include "confuse.h"
 
 int main(void)
@@ -30,6 +31,10 @@ int main(void)
 		CFG_END()
 	};
 	cfg_t *cfg;
+
+	/* Localize messages & types according to environment, since v2.9 */
+	setlocale(LC_MESSAGES, "");
+	setlocale(LC_CTYPE, "");
 
 	/* set default value for the server option */
 	server = strdup("gazonk");

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1401,13 +1401,11 @@ DLLIMPORT cfg_t *cfg_init(cfg_opt_t *opts, cfg_flag_t flags)
 	cfg->line = 0;
 	cfg->errfunc = 0;
 
-	cfg_init_defaults(cfg);
-
 #if defined(ENABLE_NLS) && defined(HAVE_GETTEXT)
-	setlocale(LC_MESSAGES, "");
-	setlocale(LC_CTYPE, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 #endif
+
+	cfg_init_defaults(cfg);
 
 	return cfg;
 }

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -549,6 +549,12 @@ extern const char __export confuse_author[];
  * whenever an unknown option is parsed. Be sure to define an "__unknown"
  * option in each scope that unknown parameters are allowed.
  *
+ * Call setlocale() before calling this function to localize handling of
+ * types, LC_CTYPE, and messages, LC_MESSAGES, since version 2.9:
+ * <pre>
+ *     setlocale(LC_MESSAGES, "");
+ *     setlocale(LC_CTYPE, "");
+ * </pre>
  * @param opts An arrary of options
  * @param flags One or more flags (bitwise or'ed together). Currently only
  * CFGF_NOCASE and CFGF_IGNORE_UNKNOWN are available. Use 0 if no flags are


### PR DESCRIPTION
As reported by Peter Rosin in GitHub issue #46, calling `setlocale()` unconditionally from within the library may interfere with and override what the application using libConfuse actually wants.

This patch removes the calls to `setlocale()`, while at the same time fixing a possible ordering issue with the call to `bindtextdomain()`, and also updates the documentation, including the examples referenced by the API documentation.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>