### PR TITLE
Fix Travis-CI problems by migrating to dockerized build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: c
 # Use docker for quicker builds, it now allows https://docs.travis-ci.com/user/apt/
 sudo: false
 
+# Test build with both GCC and Clang (LLVM)
+compiler:
+  - gcc
+  - clang
+
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 # Defaults to GNU GCC and autotools: ./configure && make && make test
 language: c
 
-# We need to install autopoint, so we cannot use dockerized build
-sudo: true
+# Use docker for quicker builds, it now allows https://docs.travis-ci.com/user/apt/
+sudo: false
 
 env:
   global:
@@ -12,6 +12,9 @@ env:
    - secure: "kFrbrFEPt+f2UTSoKymheDJiLOcuXqvCDeV8EqCIsQT7oMpwHxLogJio3BIAUfP9Ykm73roJPKOt5YVv6k8IGDvKuR5XOJDl4gfLM8S1L9shGuQwk8E7nC3/96IoVRnkuqsWseDbHBm/K6jV6TRIVRVyc4Dcbjdb7qBTuVF5VNE="
 
 addons:
+  apt:
+    packages:
+      - autopoint
   coverity_scan:
     project:
       name: "troglobit/libconfuse"
@@ -24,7 +27,6 @@ addons:
 # We don't store generated files (configure and Makefile) in GIT,
 # so we must customize the default build script to run ./autogen.sh
 script:
-  - sudo apt-get install autopoint
   - ./autogen.sh
   - ./configure
   - make


### PR DESCRIPTION
Installing autopoint using the old "sudo" method has been deprecated and now removed by Travis-CI. The new dockerized non-sudo builds work fine since autopoint is on their whitelist.