### PR TITLE
Fix warning for deprecated AM_PROG_MKDIR_P macro in AM_GNU_GETTEXT

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # (Re)Generate configure script and all build related files for i18n
 
-autoreconf -W portability -vism >/dev/null
+autoreconf -W portability -vism --force >/dev/null
 
 # Cleanup
 rm -f ABOUT-NLS

--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,11 @@ AC_ARG_ENABLE([examples],
 	[], [enable_examples=yes])
 AM_CONDITIONAL([ENABLE_EXAMPLES], [test "$enable_examples" = yes])
 
+# 0.18.2.1 updates AM_GNU_GETTEXT() to use AC_PROG_MKDIR_P instead of
+# AM_PROG_MKDIR_P, but 0.18.1.1 is included in Ubuntu 12.04 LTS.
+# Fortunately Ubuntu 14.04 LTS ships 0.18.3.1 and Debian Jessie 0.19.3
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.16.1])
+AM_GNU_GETTEXT_VERSION([0.18.3])
 
 # Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
While running autoreconf it warns for a deprecated construct that
comes from our hard coded version of gettext:

configure.ac:27: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:27: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:27: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.

This patch bumps the gettext version to 0.18.3, which is included
in the latest Ubuntu and Debian stable releases.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>