### PR TITLE
Fixed MSVC build errors

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -853,10 +853,7 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		break;
 
 	default:
-		if (value)
-			cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, value);
-		else
-			cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, "NULL");
+		cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, (value) ? (value) : "NULL");
 		return NULL;
 	}
 

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -853,7 +853,10 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		break;
 
 	default:
-		cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, value ?: "NULL");
+		if (value)
+			cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, value);
+		else
+			cfg_error(cfg, "internal error in cfg_setopt(%s, %s)", opt->name, "NULL");
 		return NULL;
 	}
 
@@ -1328,8 +1331,10 @@ static char *cfg_make_fullpath(const char *dir, const char *file)
 DLLIMPORT char *cfg_searchpath(cfg_searchpath_t *p, const char *file)
 {
 	char *fullpath;
+#ifdef HAVE_SYS_STAT_H
 	struct stat st;
 	int err;
+#endif
 
 	if (!p || !file) {
 		errno = EINVAL;


### PR DESCRIPTION
struct stat st and int err in function cfg_searchpath() aren't usable
if HAVE_SYS_STAT_H isn't defined and they break the build with MSVC.
And conditionals with omitted operands are a GNU extension and not
supported by MSVC.