### PR TITLE
Fix configure problem with gettext on CentOS/RHEL7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,8 +27,10 @@ AM_CONDITIONAL([ENABLE_EXAMPLES], [test "$enable_examples" = yes])
 # 0.18.2.1 updates AM_GNU_GETTEXT() to use AC_PROG_MKDIR_P instead of
 # AM_PROG_MKDIR_P, but 0.18.1.1 is included in Ubuntu 12.04 LTS.
 # Fortunately Ubuntu 14.04 LTS ships 0.18.3.1 and Debian Jessie 0.19.3
+# Unfortunately CentOS7, RHEL7 ships 0.18.2.1, so for best compat.
+# level at this point in time we set 0.18.2.
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.18.3])
+AM_GNU_GETTEXT_VERSION([0.18.2])
 
 # Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
Unfortunately CentOS7, RHEL7 ships 0.18.2.1, so for best compat.
level at this point in time we set 0.18.2.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>