### PR TITLE
Fix typos in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ For all new features we want to encourage developers to not only submit
 the feature (and documentation), but also at least a simple test that
 can be run from `make check`.
 
-The tests serve both as exmples and help prevent regressions.
+The tests serve both as examples and help prevent regressions.
 
 
 Coding Style

--- a/doc/tutorial.xml
+++ b/doc/tutorial.xml
@@ -256,7 +256,7 @@ greeting Bye
             in the configuration file. First it will find the "Hello" section.
             It prints the title of the section, "Hello", retrieved with
             <function>cfg_title()</function>. Then the targets are printed just
-            as in the previous exemples, but this time the values are retrieved
+            as in the previous examples, but this time the values are retrieved
             from the cfg_greet section. Next, the section titled "Bye" is
             found, and the values are retrieved from that section.
         </para>


### PR DESCRIPTION
Just fixing typos in the docs.

Signed-off-by: Luca Ceresoli <luca@lucaceresoli.net>