### PR TITLE
Fix #21: Refactor of lexer and fix memory leaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_CHECK_HEADERS([sys/stat.h])
 AC_C_CONST
 
 # Checks for library functions.
-AC_CHECK_FUNCS([strcasecmp strdup strndup setenv unsetenv _putenv])
+AC_CHECK_FUNCS([fmemopen strcasecmp strdup strndup setenv unsetenv _putenv])
 
 AC_CONFIG_FILES([Makefile \
 		 src/Makefile \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,8 +10,6 @@ datadir                = @datadir@
 localedir              = $(datadir)/locale
 DEFS                   = -DLOCALEDIR=\"$(localedir)\" @DEFS@
 LIBS                   = @LIBS@
-AM_LFLAGS              = @DEFS@ -Pcfg_yy -olex.yy.c
+AM_LFLAGS              = @DEFS@ -Pcfg_yy -olexer.c
 CLEANFILES             = *~ \#*\#
-
-lexer.c: lexer.l
 

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -52,17 +52,17 @@
 #endif
 #define N_(str) str
 
-extern int cfg_yylex(cfg_t *cfg);
-extern int cfg_lexer_include(cfg_t *cfg, const char *fname);
-extern void cfg_scan_fp_begin(FILE *fp);
-extern void cfg_scan_fp_end(void);
-extern char *cfg_qstring;
-
-char *cfg_yylval = 0;
-
 const char confuse_version[] = PACKAGE_VERSION;
 const char confuse_copyright[] = PACKAGE_STRING " by Martin Hedenfalk <martin@bzero.se>";
 const char confuse_author[] = "Martin Hedenfalk <martin@bzero.se>";
+
+char *cfg_yylval = 0;
+
+extern int  cfg_yylex(cfg_t *cfg);
+extern void cfg_yylex_destroy(void);
+extern int  cfg_lexer_include(cfg_t *cfg, const char *fname);
+extern void cfg_scan_fp_begin(FILE *fp);
+extern void cfg_scan_fp_end(void);
 
 static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t *force_opt);
 static void cfg_free_opt_array(cfg_opt_t *opts);

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -577,7 +577,12 @@ static void cfg_init_defaults(cfg_t *cfg)
 
 				fp = fmemopen(buf, strlen(buf), "r");
 				if (!fp) {
-					ret = STATE_ERROR;
+					/*
+					 * fmemopen() on older GLIBC versions do not accept zero
+					 * length buffers for some reason.  This is a workaround.
+					 */
+					if (strlen(buf) > 0)
+						ret = STATE_ERROR;
 				} else {
 					cfg_scan_fp_begin(fp);
 
@@ -1422,8 +1427,16 @@ DLLIMPORT int cfg_parse_buf(cfg_t *cfg, const char *buf)
 	cfg->filename = fn;
 
 	fp = fmemopen((void *)buf, strlen(buf), "r");
-	if (!fp)
-		return CFG_FILE_ERROR;
+	if (!fp) {
+		/*
+		 * fmemopen() on older GLIBC versions do not accept zero
+		 * length buffers for some reason.  This is a workaround.
+		 */
+		if (strlen(buf) > 0)
+			return CFG_FILE_ERROR;
+
+		return CFG_SUCCESS;
+	}
 
 	ret = cfg_parse_fp(cfg, fp);
 	fclose(fp);

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1573,6 +1573,7 @@ static int cfg_free_searchpath(cfg_searchpath_t *p)
 DLLIMPORT int cfg_free(cfg_t *cfg)
 {
 	int i;
+	int isroot = 0;
 
 	if (!cfg) {
 		errno = EINVAL;
@@ -1585,14 +1586,18 @@ DLLIMPORT int cfg_free(cfg_t *cfg)
 	cfg_free_opt_array(cfg->opts);
 	cfg_free_searchpath(cfg->path);
 
-	if (cfg->name)
+	if (cfg->name) {
+		isroot = !strcmp(cfg->name, "root");
 		free(cfg->name);
+	}
 	if (cfg->title)
 		free(cfg->title);
 	if (cfg->filename)
 		free(cfg->filename);
 
 	free(cfg);
+	if (isroot)
+		cfg_yylex_destroy();
 
 	return CFG_SUCCESS;
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -335,7 +335,7 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
  */
 static void qputc(char ch)
 {
-    if(qstring_index >= qstring_len) {
+    if (qstring_index >= qstring_len) {
         qstring_len += CFG_QSTRING_BUFSIZ;
         cfg_qstring = (char *)realloc(cfg_qstring, qstring_len);
         assert(cfg_qstring);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -64,12 +64,14 @@ static void qputc(char ch);
 
 #define MAX_INCLUDE_DEPTH 10
 struct {
-    YY_BUFFER_STATE state;
+    FILE *fp;
     char *filename;
     unsigned int line;
 } cfg_include_stack[MAX_INCLUDE_DEPTH];
 int cfg_include_stack_ptr = 0;
 
+void cfg_scan_fp_begin(FILE *fp);
+void cfg_scan_fp_end(void);
 
 %}
 
@@ -229,17 +231,19 @@ int cfg_include_stack_ptr = 0;
 }
 
 <<EOF>> {
-    if (cfg_yyin && (cfg_include_stack_ptr > 0))
+    if (cfg_include_stack_ptr > 0)
     {
-        yy_delete_buffer( YY_CURRENT_BUFFER );
-        fclose(cfg_yyin);
-        cfg_yyin = 0;
         --cfg_include_stack_ptr;
-        yy_switch_to_buffer(
-            cfg_include_stack[cfg_include_stack_ptr].state );
+        /* fp opened by cfg_lexer_include()? */
+        if (cfg_include_stack[cfg_include_stack_ptr].fp != cfg_yyin) {
+            ++cfg_include_stack_ptr;
+            return EOF;
+        }
         free(cfg->filename);
         cfg->filename = cfg_include_stack[cfg_include_stack_ptr].filename;
         cfg->line = cfg_include_stack[cfg_include_stack_ptr].line;
+        fclose(cfg_yyin);
+        cfg_scan_fp_end();
     }
     else
     {
@@ -288,6 +292,7 @@ void cfg_dummy_function(void)
 
 int cfg_lexer_include(cfg_t *cfg, const char *filename)
 {
+    FILE *fp;
     char *xfilename;
 
     if (cfg_include_stack_ptr >= MAX_INCLUDE_DEPTH) 
@@ -296,10 +301,8 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
         return CFG_PARSE_ERROR;
     }
 
-    cfg_include_stack[cfg_include_stack_ptr].state = YY_CURRENT_BUFFER;
     cfg_include_stack[cfg_include_stack_ptr].filename = cfg->filename;
     cfg_include_stack[cfg_include_stack_ptr].line = cfg->line;
-    cfg_include_stack_ptr++;
 
     if (cfg->path)
     {
@@ -320,19 +323,19 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
         }
     }
 
-    cfg_yyin = fopen(xfilename, "r");
-
-    if (!cfg_yyin) 
-      {
+    fp = fopen(xfilename, "r");
+    if (!fp)
+    {
         cfg_error(cfg, "%s: %s", xfilename, strerror(errno));
         free(xfilename);
         return CFG_PARSE_ERROR;
-      }
+    }
 
+    cfg_include_stack[cfg_include_stack_ptr].fp = fp;
+    cfg_include_stack_ptr++;
     cfg->filename = xfilename;
     cfg->line = 1;
-
-    yy_switch_to_buffer(yy_create_buffer(cfg_yyin, YY_BUF_SIZE));
+    cfg_scan_fp_begin(fp);
 
     return CFG_SUCCESS;
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -351,24 +351,16 @@ static void qputc(char ch)
     cfg_qstring[qstring_index++] = ch;
 }
 
-static YY_BUFFER_STATE pre_fp_scan_state;
-static YY_BUFFER_STATE fp_scan_state;
-
 void cfg_scan_fp_begin(FILE *fp)
 {
-    pre_fp_scan_state = YY_CURRENT_BUFFER;
-    fp_scan_state = yy_create_buffer(fp, YY_BUF_SIZE);
-    yy_switch_to_buffer(fp_scan_state);
+    cfg_yypush_buffer_state(cfg_yy_create_buffer(fp, YY_BUF_SIZE));
 }
 
 void cfg_scan_fp_end(void)
 {
-    /* restore to previous state
-     */
-    yy_delete_buffer(fp_scan_state);
-    if(pre_fp_scan_state)
-        yy_switch_to_buffer(pre_fp_scan_state);
-    free(cfg_qstring);
+    if (cfg_qstring)
+	    free(cfg_qstring);
     cfg_qstring = 0;
     qstring_index = qstring_len = 0;
+    cfg_yypop_buffer_state();
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -70,8 +70,6 @@ struct {
 } cfg_include_stack[MAX_INCLUDE_DEPTH];
 int cfg_include_stack_ptr = 0;
 
-static YY_BUFFER_STATE pre_string_scan_state = 0;
-static YY_BUFFER_STATE string_scan_state = 0;
 
 %}
 
@@ -351,28 +349,6 @@ static void qputc(char ch)
         memset(cfg_qstring + qstring_index, 0, CFG_QSTRING_BUFSIZ);
     }
     cfg_qstring[qstring_index++] = ch;
-}
-
-void cfg_scan_string_begin(const char *buf)
-{
-    pre_string_scan_state = YY_CURRENT_BUFFER;
-
-    /* yy_scan_string does a yy_switch_to_buffer call for us
-     */
-    string_scan_state = yy_scan_string(buf);
-}
-
-void cfg_scan_string_end(void)
-{
-    /* restore to previous state
-     */
-    yy_delete_buffer(string_scan_state);
-    if (pre_string_scan_state)
-        yy_switch_to_buffer(pre_string_scan_state);
-    free(cfg_qstring);
-    cfg_qstring = 0;
-    qstring_index = qstring_len = 0;
-    string_scan_state = 0;
 }
 
 static YY_BUFFER_STATE pre_fp_scan_state;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -305,13 +305,22 @@ int cfg_lexer_include(cfg_t *cfg, const char *filename)
 
     if (cfg->path)
     {
-	if ((xfilename = cfg_searchpath(cfg->path, filename)) == NULL)
-	{
-	    cfg_error(cfg, "%s: Not found on searchpath", xfilename);
-	    return CFG_PARSE_ERROR;
-	}
+        xfilename = cfg_searchpath(cfg->path, filename);
+        if (!xfilename)
+        {
+            cfg_error(cfg, _("%s: Not found in search path"), filename);
+            return CFG_PARSE_ERROR;
+        }
     }
-    else xfilename = cfg_tilde_expand(filename);
+    else
+    {
+        xfilename = cfg_tilde_expand(filename);
+        if (!xfilename)
+        {
+            cfg_error(cfg, _("%s: Failed tilde expand"), filename);
+            return CFG_PARSE_ERROR;
+        }
+    }
 
     cfg_yyin = fopen(xfilename, "r");
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,6 +5,7 @@ env
 ignore_parm
 list_plus_syntax
 malloc.log
+section_add
 section_remove
 section_title_dupes
 suite_dup

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,6 +20,7 @@ TESTS            += ignore_parm
 check_PROGRAMS    = $(TESTS)
 
 DEFS              = -DSRC_DIR='"$(srcdir)"'
+LDFLAGS           = -static
 LDADD             = -L../src ../src/libconfuse.la $(LTLIBINTL)
 CLEANFILES        = *~
 

--- a/tests/section_title_dupes.c
+++ b/tests/section_title_dupes.c
@@ -22,7 +22,7 @@ int main(void)
 	const char *config_data =
 		"section title_one { prop = 'value_one' }\n"
 		"section title_two { prop = 'value_two' }\n"
-		"section title_one { prop = 'value_one' }\n";
+		"section title_one { prop = 'value_one' }\n"; /* Duplicate! */
 
 	int rc;
 	cfg_t *cfg = cfg_init(opts, CFGF_NONE);


### PR DESCRIPTION
This patch series unifies the API between the lexer and the `confuse.c` parser, simplifies the code, and fixes a few memory leaks due to unclosed file descriptors, lost `strdup()`'s, and, most importantly, adds a call to `cfg_yylex_destroy()` in `cfg_free()` as proposed in #21.

Seeing as this is quite a big pull request I will let it sit for a while to allow for a proper review.