### PR TITLE
Fix #79: Add fmemopen() support using BSD funopen()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,10 @@ AC_C_CONST
 # Checks for library functions.
 AC_CHECK_FUNCS([fmemopen strcasecmp strdup strndup setenv unsetenv _putenv])
 
+# Set conditional includes in Makefile.am
+AM_CONDITIONAL(MISSING_FMEMOPEN, [test "x$ac_cv_func_fmemopen" = "xno"])
+
+# Files to generate
 AC_CONFIG_FILES([Makefile \
 		 src/Makefile \
 		 examples/Makefile \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,3 +13,6 @@ LIBS                   = @LIBS@
 AM_LFLAGS              = @DEFS@ -Pcfg_yy -olexer.c
 CLEANFILES             = *~ \#*\#
 
+if MISSING_FMEMOPEN
+libconfuse_la_SOURCES += fmemopen.c
+endif

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -71,6 +71,10 @@ static void cfg_free_opt_array(cfg_opt_t *opts);
 #define STATE_EOF -1
 #define STATE_ERROR 1
 
+#ifndef HAVE_FMEMOPEN
+extern FILE *fmemopen(void *buf, size_t size, const char *type);
+#endif
+
 #ifndef HAVE_STRDUP
 # ifdef HAVE__STRDUP
 #  define strdup _strdup

--- a/src/fmemopen.c
+++ b/src/fmemopen.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017  Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+
+struct ops {
+	char   *buf;
+	size_t  len, pos;
+};
+
+typedef struct ops ops_t;
+
+static int readfn(void *arg, char *buf, int len)
+{
+	int sz;
+	ops_t *ops = (ops_t *)arg;
+
+	sz = (int)(ops->len - ops->pos);
+	if (sz < 0)
+		sz = 0;
+	if (len > sz)
+		len = sz;
+
+	memcpy(buf, &ops->buf[ops->pos], len);
+	ops->pos += len;
+
+	return len;
+}
+
+static int writefn(void *arg, const char *buf, int len)
+{
+	int sz;
+	ops_t *ops = (ops_t *)arg;
+
+	sz = (int)(ops->len - ops->pos);
+	if (sz < 0)
+		sz = 0;
+	if (len > sz)
+		len = sz;
+
+	memcpy(&ops->buf[ops->pos], buf, len);
+	ops->pos += len;
+
+	return len;
+}
+
+static fpos_t seekfn(void *arg, fpos_t offset, int whence)
+{
+	fpos_t pos;
+	ops_t *ops = (ops_t *)arg;
+
+	switch (whence) {
+	case SEEK_SET:
+		pos = offset;
+		break;
+
+	case SEEK_END:
+		pos = ops->len + offset;
+		break;
+
+	case SEEK_CUR:
+		pos = ops->pos + offset;
+		break;
+
+	default:
+		return -1;
+	}
+
+	if (pos < 0 || (size_t)pos > ops->len) {
+		ops->pos = 0;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int closefn(void *arg)
+{
+	free(arg);
+	return 0;
+}
+
+FILE *fmemopen(void *buf, size_t len, const char *type)
+{
+	ops_t *ops = malloc(sizeof(*ops));
+
+	if (!ops)
+		return NULL;
+
+	memset(ops, 0, sizeof(*ops));
+	ops->buf = buf;
+	ops->len = len;
+	ops->pos = 0;
+
+	return funopen(ops, readfn, writefn, seekfn, closefn);
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */


### PR DESCRIPTION
Tested on MacOS X El Capitan 10.11.6

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>