### PR TITLE
Annotate fixes

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1093,6 +1093,9 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				break;
 
 			case CFGT_COMMENT:
+				if (!is_set(CFGF_COMMENTS, cfg->flags))
+					continue;
+
 				if (comment)
 					free(comment);
 				comment = strdup(cfg_yylval);
@@ -2162,7 +2165,7 @@ DLLIMPORT int cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent)
 		return CFG_FAIL;
 	}
 
-	if (opt->comment) {
+	if (is_set(CFGF_COMMENTS, opt->flags) && opt->comment) {
 		cfg_indent(fp, indent);
 		fprintf(fp, "/* %s */\n", opt->comment);
 	}

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -94,6 +94,7 @@ typedef enum cfg_type_t cfg_type_t;
 #define CFGF_IGNORE_UNKNOWN 256 /**< ignore unknown options in configuration files */
 #define CFGF_DEPRECATED     512  /**< option is deprecated and should be ignored. */
 #define CFGF_DROP           1024 /**< option should be dropped after parsing */
+#define CFGF_COMMENTS       2048 /**< Enable option annotation/comments support */
 
 /** Return codes from cfg_parse(), cfg_parse_boolean(), and cfg_set*() functions. */
 #define CFG_SUCCESS     0

--- a/tests/annotate.c
+++ b/tests/annotate.c
@@ -21,7 +21,7 @@ int main(void)
 	cfg = cfg_init(opts, CFGF_NONE);
 	fail_unless(cfg != NULL);
 
-	fail_unless(cfg_parse(cfg, "annotate.conf") == CFG_SUCCESS);
+	fail_unless(cfg_parse(cfg, SRC_DIR "/annotate.conf") == CFG_SUCCESS);
 
 	opt = cfg_getopt(cfg, "section|option");
 	fail_unless(strcmp(cfg_opt_getcomment(opt), expect) == 0);

--- a/tests/annotate.c
+++ b/tests/annotate.c
@@ -3,6 +3,7 @@
 
 int main(void)
 {
+	char *comment;
 	char *expect = "A comment we think will go with this option";
 	cfg_t *cfg;
 	cfg_opt_t *opt;
@@ -18,13 +19,16 @@ int main(void)
 		CFG_END()
 	};
 
-	cfg = cfg_init(opts, CFGF_NONE);
+	cfg = cfg_init(opts, CFGF_COMMENT);
 	fail_unless(cfg != NULL);
 
 	fail_unless(cfg_parse(cfg, SRC_DIR "/annotate.conf") == CFG_SUCCESS);
 
 	opt = cfg_getopt(cfg, "section|option");
-	fail_unless(strcmp(cfg_opt_getcomment(opt), expect) == 0);
+	fail_unless(opt != NULL);
+	comment = cfg_opt_getcomment(opt);
+	fail_unless(comment != NULL);
+	fail_unless(strcmp(comment, expect) == 0);
 
 	fail_unless(cfg_opt_setcomment(opt, "But what's the worst poetry in the universe?") == CFG_SUCCESS);
 


### PR DESCRIPTION
- Fix search path for annotate.conf when using separate build directory
- Conditionalize option annotation, user must set CFGF_COMMENTS to enable feature