### PR TITLE
Annotate fixes

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1118,6 +1118,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 
 			/* Inherit last read comment */
 			opt->comment = comment;
+			opt->flags  |= CFGF_COMMENTS;
 			comment = NULL;
 
 			if (opt->type == CFGT_SEC) {
@@ -1780,6 +1781,7 @@ DLLIMPORT int cfg_opt_setcomment(cfg_opt_t *opt, char *comment)
 	if (opt->comment)
 		free(opt->comment);
 	opt->comment = strdup(comment);
+	opt->flags  |= CFGF_COMMENTS;
 
 	return CFG_SUCCESS;
 }

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1073,6 +1073,9 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			if (opt && opt->flags & CFGF_DEPRECATED)
 				cfg_handle_deprecated(cfg, opt);
 
+			if (comment)
+				free(comment);
+
 			return STATE_EOF;
 		}
 
@@ -1087,6 +1090,9 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 					cfg_error(cfg, _("unexpected closing brace"));
 					goto error;
 				}
+				if (comment)
+					free(comment);
+
 				return STATE_EOF;
 
 			case CFGT_STR:
@@ -1325,6 +1331,9 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			} else if (tok == CFGT_STR) {
 				state = 11; /* No '=' ... must be a titled section */
 			} else if (tok == '}' && force_state == 10) {
+				if (comment)
+					free(comment);
+
 				return STATE_CONTINUE;
 			}
 			break;
@@ -1356,8 +1365,12 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			}
 
 			/* Are we done with recursive ignore of sub-section? */
-			if (force_state == 10)
+			if (force_state == 10) {
+				if (comment)
+					free(comment);
+
 				return STATE_CONTINUE;
+			}
 
 			ignore = 0;
 			state = 0;
@@ -1391,6 +1404,9 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			goto error;
 		}
 	}
+
+	if (comment)
+		free(comment);
 
 	return STATE_EOF;
 

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1662,6 +1662,11 @@ DLLIMPORT int cfg_free_value(cfg_opt_t *opt)
 		return CFG_FAIL;
 	}
 
+	if (opt->comment) {
+		free(opt->comment);
+		opt->comment = NULL;
+	}
+
 	if (opt->values) {
 		unsigned int i;
 
@@ -1691,6 +1696,8 @@ static void cfg_free_opt_array(cfg_opt_t *opts)
 
 	for (i = 0; opts[i].name; ++i) {
 		free((void *)opts[i].name);
+		if (opts[i].comment)
+			free(opts[i].comment);
 		if (opts[i].def.parsed)
 			free(opts[i].def.parsed);
 		if (opts[i].def.string)
@@ -1721,6 +1728,9 @@ DLLIMPORT int cfg_free(cfg_t *cfg)
 		errno = EINVAL;
 		return CFG_FAIL;
 	}
+
+	if (cfg->comment)
+		free(cfg->comment);
 
 	for (i = 0; cfg->opts[i].name; ++i)
 		cfg_free_value(&cfg->opts[i]);

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -190,7 +190,7 @@ DLLIMPORT cfg_opt_t *cfg_getopt(cfg_t *cfg, const char *name)
 
 			sec = cfg_getsec(sec, secname);
 			if (!sec) {
-				if (!(cfg->flags & CFGF_IGNORE_UNKNOWN))
+				if (!is_set(CFGF_IGNORE_UNKNOWN, cfg->flags))
 					cfg_error(cfg, _("no such option '%s'"), secname);
 				free(secname);
 				return NULL;
@@ -211,7 +211,7 @@ DLLIMPORT cfg_opt_t *cfg_getopt(cfg_t *cfg, const char *name)
 		}
 	}
 
-	if (!(cfg->flags & CFGF_IGNORE_UNKNOWN))
+	if (!is_set(CFGF_IGNORE_UNKNOWN, cfg->flags))
 		cfg_error(cfg, _("no such option '%s'"), name);
 
 	return NULL;
@@ -1031,7 +1031,7 @@ static int call_function(cfg_t *cfg, cfg_opt_t *opt, cfg_opt_t *funcopt)
 
 static void cfg_handle_deprecated(cfg_t *cfg, cfg_opt_t *opt)
 {
-	if (opt->flags & CFGF_DROP) {
+	if (is_set(CFGF_DROP, opt->flags)) {
 		cfg_error(cfg, _("dropping deprecated configuration option '%s'"), opt->name);
 		cfg_free_value(opt);
 	} else {
@@ -1070,7 +1070,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				goto error;
 			}
 
-			if (opt && opt->flags & CFGF_DEPRECATED)
+			if (opt && is_set(CFGF_DEPRECATED, opt->flags))
 				cfg_handle_deprecated(cfg, opt);
 
 			if (comment)
@@ -1081,7 +1081,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 
 		switch (state) {
 		case 0:	/* expecting an option name */
-			if (opt && opt->flags & CFGF_DEPRECATED)
+			if (opt && is_set(CFGF_DEPRECATED, opt->flags))
 				cfg_handle_deprecated(cfg, opt);
 
 			switch (tok) {
@@ -1114,7 +1114,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 
 			opt = cfg_getopt(cfg, cfg_yylval);
 			if (!opt) {
-				if (cfg->flags & CFGF_IGNORE_UNKNOWN) {
+				if (is_set(CFGF_IGNORE_UNKNOWN, cfg->flags)) {
 					state = 10;
 					break;
 				}

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1662,7 +1662,7 @@ DLLIMPORT int cfg_free_value(cfg_opt_t *opt)
 		return CFG_FAIL;
 	}
 
-	if (opt->comment) {
+	if (opt->comment && !is_set(CFGF_RESET, opt->flags)) {
 		free(opt->comment);
 		opt->comment = NULL;
 	}

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -1187,8 +1187,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				goto error;
 
 			/* Inherit last read comment */
-			opt->comment = comment;
-			opt->flags  |= CFGF_COMMENTS;
+			cfg_opt_setcomment(opt, comment);
 			comment = NULL;
 
 			if (opt && is_set(CFGF_LIST, opt->flags)) {

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -693,8 +693,13 @@ DLLIMPORT void __export cfg_error(cfg_t *cfg, const char *fmt, ...);
 DLLIMPORT char * __export cfg_opt_getcomment(cfg_opt_t *opt);
 
 /** Returns the option comment
+ *
+ * This function can be used to extract option annotations from a config
+ * file.  Only comments preceding the option are read by cfg_parse().
+ *
  * @param cfg The configuration file context.
  * @param name The name of the option.
+ * @see cfg_setcomment
  * @return The comment for this option, or NULL if unset
  */
 DLLIMPORT char * __export cfg_getcomment(cfg_t *cfg, const char *name);
@@ -957,17 +962,29 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 /** Annotate an option
  * @param opt The option structure (eg, as returned from cfg_getopt())
  * @param comment The annotation
- *
+ * @see cfg_setcomment
  * @return POSIX OK(0), or non-zero on failure.
  */
 DLLIMPORT int __export cfg_opt_setcomment(cfg_opt_t *opt, char *comment);
 
-/** Annotate an option by its name
+/** Annotate an option given its name
+ *
+ * All options can be annotated as long as the CFGF_COMMENTS flag is
+ * given to cfg_init().  Comments are reset when an option is given
+ * a new value, so the annotation must be set after the value.
+ *
+ * When calling cfg_print(), annotations are saved as a C style one-liner
+ * comment before each option.
+ *
+ * When calling cfg_parse(), only one-liner comments preceding an option
+ * are read and used to annotate the option.
+ *
  * @param cfg The configuration file context.
  * @param name The name of the option.
  * @param comment The annotation
  *
- * @return POSIX OK(0), or non-zero on failure.
+ * @return POSIX OK(0), or non-zero on failure.  This function will fail
+ * if memory for the new comment cannot be allocated.
  */
 DLLIMPORT int __export cfg_setcomment(cfg_t *cfg, const char *name, char *comment);
 

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -970,8 +970,7 @@ DLLIMPORT int __export cfg_opt_setcomment(cfg_opt_t *opt, char *comment);
 /** Annotate an option given its name
  *
  * All options can be annotated as long as the CFGF_COMMENTS flag is
- * given to cfg_init().  Comments are reset when an option is given
- * a new value, so the annotation must be set after the value.
+ * given to cfg_init().
  *
  * When calling cfg_print(), annotations are saved as a C style one-liner
  * comment before each option.

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,6 @@
 .deps
 .libs
+annotate
 check_confuse
 env
 ignore_parm

--- a/tests/annotate.c
+++ b/tests/annotate.c
@@ -24,13 +24,25 @@ int main(void)
 
 	fail_unless(cfg_parse(cfg, SRC_DIR "/annotate.conf") == CFG_SUCCESS);
 
+	/* Verify the parser read the correct comment for this tricky option */
 	opt = cfg_getopt(cfg, "section|option");
 	fail_unless(opt != NULL);
 	comment = cfg_opt_getcomment(opt);
 	fail_unless(comment != NULL);
 	fail_unless(strcmp(comment, expect) == 0);
 
-	fail_unless(cfg_opt_setcomment(opt, "But what's the worst poetry in the universe?") == CFG_SUCCESS);
+	expect = "But what's the worst poetry in the universe?";
+	fail_unless(cfg_opt_setcomment(opt, expect) == CFG_SUCCESS);
+
+	cfg_opt_setnstr(opt, "Paula Nancy Millstone Jennings was a poet who wrote the worst poetry in "
+			"the universe. In fact, her poetry is still considered to be the worst in "
+			"the Galaxy, closely followed by that of the Azgoths of Kria and the "
+			"Vogons, in that order.", 0);
+
+	/* Verify that the comment is not reset when changing option value */
+	comment = cfg_opt_getcomment(opt);
+	fail_unless(comment != NULL);
+	fail_unless(strcmp(comment, expect) == 0);
 
 	cfg_print(cfg, stdout);
 	fail_unless(cfg_free(cfg) == CFG_SUCCESS);

--- a/tests/annotate.c
+++ b/tests/annotate.c
@@ -19,7 +19,7 @@ int main(void)
 		CFG_END()
 	};
 
-	cfg = cfg_init(opts, CFGF_COMMENT);
+	cfg = cfg_init(opts, CFGF_COMMENTS);
 	fail_unless(cfg != NULL);
 
 	fail_unless(cfg_parse(cfg, SRC_DIR "/annotate.conf") == CFG_SUCCESS);


### PR DESCRIPTION
- Fix annotate unit test
- Make sure to set `CFGF_COMMENTS` flag for comments
- Add `free()` of comments on `cfg_free()`
- Fix fallout from flipping semantics on comment flag
- Misc. refactor and cleanup
