### PR TITLE
Add static lib building support for Windows

### DIFF
--- a/src/confuse.h
+++ b/src/confuse.h
@@ -51,11 +51,15 @@ extern "C" {
 # ifdef HAVE__ISATTY
 #  define isatty _isatty
 # endif
-# ifdef BUILDING_DLL
-#  define DLLIMPORT __declspec (dllexport)
-# else /* ! BUILDING_DLL */
-#  define DLLIMPORT __declspec (dllimport)
-# endif /* BUILDING_DLL */
+# ifdef BUILDING_STATIC
+#  define DLLIMPORT
+# else /* ! BUILDING_STATIC */
+#  ifdef BUILDING_DLL
+#   define DLLIMPORT __declspec (dllexport)
+#  else /* ! BUILDING_DLL */
+#   define DLLIMPORT __declspec (dllimport)
+#  endif /* BUILDING_DLL */
+# endif /* BUILDING_STATIC */
 #else /* ! _WIN32 || __GNUC__ */
 # define DLLIMPORT
 #endif /* _WIN32 */


### PR DESCRIPTION
On Windows, `DLLIMPORT` is expanded as `__declspec (dllexport)` or `__declspec (dllimport)` . All these two forms is not suitable for building `libconfuse` as a static library.

And since`confuse.c` includes `config.h` first, just before including `confuse.h`:
```c
#ifdef HAVE_CONFIG_H
# include <config.h>
#endif
...
#include "confuse.h"
```
so it is not possible to redefine `DLLIMPORT` in `config.h`.

This patch provides static library building support for Windows by adding a `BUILDING_STATIC` macro.