### PR TITLE
Fix Linux coding style link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Bill & Ted; be excellent to each other.
 
 [github]:   https://github.com/martinh/libconfuse/
 [KNF]:      https://en.wikipedia.org/wiki/Kernel_Normal_Form
-[style]:    https://www.kernel.org/doc/Documentation/CodingStyle
+[style]:    https://www.kernel.org/doc/html/latest/process/coding-style.html
 [gitbook]:  https://git-scm.com/book/ch5-2.html
 [rambling]: http://stopwritingramblingcommitmessages.com/
 

--- a/indent.sh
+++ b/indent.sh
@@ -4,7 +4,7 @@
 # remember: "indent" is not a fix for bad programming.
 # 
 # Rules:
-#   - Linux style, https://www.kernel.org/doc/Documentation/CodingStyle
+#   - Linux style, https://www.kernel.org/doc/Documentation/process/coding-style.rst
 #   - Don't touch comment content/formatting, only placement.
 #   - ignore any ~/.indent.pro
 #


### PR DESCRIPTION
Linux coding style link in https://github.com/martinh/libconfuse/blob/master/CONTRIBUTING.md has been moved to another page: https://www.kernel.org/doc/Documentation/process/coding-style.rst
There is also a HTML version of this page: https://www.kernel.org/doc/html/latest/process/coding-style.html
This PR updates the coding style link in `CONTRIBUTING.md` to the HTML version and updates the link in `indent.sh` to the non-HTML version. 