### PR TITLE
fmemopen.c: Add UWP support

### DIFF
--- a/src/fmemopen.c
+++ b/src/fmemopen.c
@@ -118,6 +118,7 @@ FILE *fmemopen(void *buf, size_t len, const char *type)
 #elif defined(HAVE_WINDOWS_H)
 #include <io.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <windows.h>
 
 FILE *fmemopen(void *buf, size_t len, const char *type)
@@ -126,28 +127,22 @@ FILE *fmemopen(void *buf, size_t len, const char *type)
 	FILE *fp;
 	char tp[MAX_PATH - 13];
 	char fn[MAX_PATH + 1];
-	HANDLE h;
 
-	if (!GetTempPath(sizeof(tp), tp))
+	if (!GetTempPathA(sizeof(tp), tp))
 		return NULL;
 
-	if (!GetTempFileName(tp, "confuse", 0, fn))
+	if (!GetTempFileNameA(tp, "confuse", 0, fn))
 		return NULL;
 
-	h = CreateFile(fn, GENERIC_READ | GENERIC_WRITE, 0, NULL,
-		       CREATE_ALWAYS, FILE_FLAG_DELETE_ON_CLOSE, NULL);
-	if (INVALID_HANDLE_VALUE == h)
+	fd = _open(fn,
+		_O_CREAT | _O_RDWR | _O_SHORT_LIVED | _O_TEMPORARY | _O_BINARY,
+		_S_IREAD | _S_IWRITE);
+	if (fd == -1)
 		return NULL;
 
-	fd = _open_osfhandle((intptr_t)h, _O_APPEND);
-	if (fd < 0) {
-		CloseHandle(h);
-		return NULL;
-	}
-
-	fp = fdopen(fd, "w+");
+	fp = _fdopen(fd, "w+");
 	if (!fp) {
-		CloseHandle(h);
+		_close(fd);
 		return NULL;
 	}
 


### PR DESCRIPTION
On Windows, we can not use 'CreateFile' within an UWP application:
> warning C4013: 'CreateFile' undefined; assuming extern returning int

(UWP applications can use CreateFile2 though. An example: https://github.com/microsoft/vcpkg/blob/master/ports/libsndfile/uwp-createfile-getfilesize.patch)

This patch uses `_open` as a replacement of `CreateFile`:
https://github.com/DanBloomberg/leptonica/blob/4972d55fcddee5c51f393747848c87fa54a64a78/src/utils2.c#L1926-L1973

Test with UWP under this PR: https://github.com/microsoft/vcpkg/pull/7252