### PR TITLE
cfg_dupopt_array fixes

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -493,22 +493,19 @@ static cfg_opt_t *cfg_dupopt_array(cfg_opt_t *opts)
 		if (!dupopts[i].name)
 			goto err;
 
-		if (opts[i].type == CFGT_SEC && opts[i].subopts) {
+		if (opts[i].subopts) {
 			dupopts[i].subopts = cfg_dupopt_array(opts[i].subopts);
 			if (!dupopts[i].subopts)
 				goto err;
 		}
 
-		if (is_set(CFGF_LIST, opts[i].flags) || opts[i].type == CFGT_FUNC) {
-			dupopts[i].def.parsed = opts[i].def.parsed ? strdup(opts[i].def.parsed) : NULL;
-			if (opts[i].def.parsed && !dupopts[i].def.parsed)
-				goto err;
-		}
-		else if (opts[i].type == CFGT_STR) {
-			dupopts[i].def.string = opts[i].def.string ? strdup(opts[i].def.string) : NULL;
-			if (opts[i].def.string && !dupopts[i].def.string)
-				goto err;
-		}
+		dupopts[i].def.parsed = opts[i].def.parsed ? strdup(opts[i].def.parsed) : NULL;
+		if (opts[i].def.parsed && !dupopts[i].def.parsed)
+			goto err;
+
+		dupopts[i].def.string = opts[i].def.string ? strdup(opts[i].def.string) : NULL;
+		if (opts[i].def.string && !dupopts[i].def.string)
+			goto err;
 
 		dupopts[i].comment = opts[i].comment ? strdup(opts[i].comment) : NULL;
 		if (opts[i].comment && !dupopts[i].comment)

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -489,6 +489,15 @@ static cfg_opt_t *cfg_dupopt_array(cfg_opt_t *opts)
 	memcpy(dupopts, opts, n * sizeof(cfg_opt_t));
 
 	for (i = 0; i < n; i++) {
+		/* Clear dynamic ptrs, protecting the original on failure */
+		dupopts[i].name = NULL;
+		dupopts[i].subopts = NULL;
+		dupopts[i].def.parsed = NULL;
+		dupopts[i].def.string = NULL;
+		dupopts[i].comment = NULL;
+	}
+
+	for (i = 0; i < n; i++) {
 		dupopts[i].name = strdup(opts[i].name);
 		if (!dupopts[i].name)
 			goto err;

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -508,17 +508,23 @@ static cfg_opt_t *cfg_dupopt_array(cfg_opt_t *opts)
 				goto err;
 		}
 
-		dupopts[i].def.parsed = opts[i].def.parsed ? strdup(opts[i].def.parsed) : NULL;
-		if (opts[i].def.parsed && !dupopts[i].def.parsed)
-			goto err;
+		if (opts[i].def.parsed) {
+			dupopts[i].def.parsed = strdup(opts[i].def.parsed);
+			if (!dupopts[i].def.parsed)
+				goto err;
+		}
 
-		dupopts[i].def.string = opts[i].def.string ? strdup(opts[i].def.string) : NULL;
-		if (opts[i].def.string && !dupopts[i].def.string)
-			goto err;
+		if (opts[i].def.string) {
+			dupopts[i].def.string = strdup(opts[i].def.string);
+			if (!dupopts[i].def.string)
+				goto err;
+		}
 
-		dupopts[i].comment = opts[i].comment ? strdup(opts[i].comment) : NULL;
-		if (opts[i].comment && !dupopts[i].comment)
-			goto err;
+		if (opts[i].comment) {
+			dupopts[i].comment = strdup(opts[i].comment);
+			if (!dupopts[i].comment)
+				goto err;
+		}
 	}
 
 	return dupopts;

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -509,6 +509,10 @@ static cfg_opt_t *cfg_dupopt_array(cfg_opt_t *opts)
 			if (opts[i].def.string && !dupopts[i].def.string)
 				goto err;
 		}
+
+		dupopts[i].comment = opts[i].comment ? strdup(opts[i].comment) : NULL;
+		if (opts[i].comment && !dupopts[i].comment)
+			goto err;
 	}
 
 	return dupopts;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,7 @@ TESTS            += suite_dup
 TESTS            += suite_func
 TESTS            += suite_list
 TESTS            += suite_validate
+TESTS            += suite_ptr
 TESTS            += list_plus_syntax
 TESTS            += section_title_dupes
 TESTS            += single_title_sections
@@ -17,6 +18,9 @@ TESTS            += searchpath
 TESTS            += env
 TESTS            += ignore_parm
 TESTS            += annotate
+
+XFAIL_TESTS       =
+XFAIL_TESTS      += suite_ptr
 
 check_PROGRAMS    = $(TESTS)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,9 +19,6 @@ TESTS            += env
 TESTS            += ignore_parm
 TESTS            += annotate
 
-XFAIL_TESTS       =
-XFAIL_TESTS      += suite_ptr
-
 check_PROGRAMS    = $(TESTS)
 
 DEFS              = -DSRC_DIR='"$(srcdir)"'

--- a/tests/suite_ptr.c
+++ b/tests/suite_ptr.c
@@ -1,0 +1,50 @@
+#include "check_confuse.h"
+#include <string.h>
+
+static int parse_ptr(cfg_t *cfg, cfg_opt_t *opt,
+		     const char *value, void *result)
+{
+	int *ptr;
+
+	if (!strcmp(value, "nil")) {
+		*(void **)result = NULL;
+		return 0;
+	}
+
+	ptr = malloc(sizeof(int));
+	if (!ptr)
+		return -1;
+
+	*ptr = atoi(value);
+	*(void **)result = ptr;
+	return 0;
+}
+
+int main(void)
+{
+	cfg_opt_t opts[] = {
+		CFG_PTR_CB("ptr", 0, CFGF_NONE, parse_ptr, free),
+		CFG_PTR_CB("ptr-nil", "nil", CFGF_NONE, parse_ptr, free),
+		CFG_PTR_CB("ptr-one", "1", CFGF_NONE, parse_ptr, free),
+		CFG_END()
+	};
+
+	cfg_t *cfg = cfg_init(opts, 0);
+	fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "ptr") == 0);
+	fail_unless(cfg_getptr(cfg, "ptr") == 0);
+	fail_unless(cfg_size(cfg, "ptr-nil") == 1);
+	fail_unless(cfg_getptr(cfg, "ptr-nil") == 0);
+	fail_unless(cfg_size(cfg, "ptr-one") == 1);
+	fail_unless(cfg_getptr(cfg, "ptr-one") != 0);
+	cfg_free(cfg);
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */


### PR DESCRIPTION
I noticed that comments where not strdup-ed, which would lead to use -after-free and eventually a double-free, if/when both the copy and the original try to free the same comment. I think this is perhaps not normally a problem because comments are not used heavily?

The second patch similarly prevents use-after-free and double-free if the dupopt operation fails in the middle. Failure should be rare though.