### PR TITLE
Print empty strings without commenting them out

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -2260,14 +2260,9 @@ DLLIMPORT int cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent)
 		} else {
 			cfg_indent(fp, indent);
 			/* comment out the option if is not set */
-			if (opt->simple_value.ptr) {
-				if (opt->type == CFGT_STR && *opt->simple_value.string == 0)
-					fprintf(fp, "# ");
-			} else {
-				if (cfg_opt_size(opt) == 0 || (opt->type == CFGT_STR && (opt->values[0]->string == 0 ||
-											 opt->values[0]->string[0] == 0)))
-					fprintf(fp, "# ");
-			}
+			if (cfg_opt_size(opt) == 0 ||
+			    (opt->type == CFGT_STR && !cfg_opt_getnstr(opt, 0)))
+				fprintf(fp, "# ");
 			fprintf(fp, "%s=", opt->name);
 			if (opt->pf)
 				opt->pf(opt, 0, fp);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,6 +18,10 @@ TESTS            += searchpath
 TESTS            += env
 TESTS            += ignore_parm
 TESTS            += annotate
+TESTS            += empty_string
+
+XFAIL_TESTS       =
+XFAIL_TESTS      += empty_string
 
 check_PROGRAMS    = $(TESTS)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,9 +20,6 @@ TESTS            += ignore_parm
 TESTS            += annotate
 TESTS            += empty_string
 
-XFAIL_TESTS       =
-XFAIL_TESTS      += empty_string
-
 check_PROGRAMS    = $(TESTS)
 
 DEFS              = -DSRC_DIR='"$(srcdir)"'

--- a/tests/empty_string.c
+++ b/tests/empty_string.c
@@ -1,0 +1,50 @@
+#include "check_confuse.h"
+#include <stdio.h>
+#include <string.h>
+
+#ifndef HAVE_FMEMOPEN
+extern FILE *fmemopen(void *buf, size_t size, const char *type);
+#endif
+
+int main(void)
+{
+	cfg_opt_t opts[] = {
+		CFG_STR("string", "hello", CFGF_NONE),
+		CFG_END()
+	};
+	cfg_t *cfg;
+	char buf[100]; /* should be enough */
+	FILE *f;
+
+	/*
+	 * override the default with a config with an empty string
+	 * and then generate a temporary config file with that
+	 */
+	cfg = cfg_init(opts, 0);
+	fail_unless(cfg_parse_buf(cfg, "string = ''") == CFG_SUCCESS);
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "") == 0);
+	f = fmemopen(buf, sizeof(buf), "w+");
+	fail_unless(f != NULL);
+	cfg_print(cfg, f);
+	cfg_free(cfg);
+
+	/*
+	 * try to reload the generated temporary config file to check
+	 * that the default is indeed overridden by an empty string
+	 */
+	cfg = cfg_init(opts, 0);
+	fseek(f, 0L, SEEK_SET);
+	fail_unless(cfg_parse_fp(cfg, f) == CFG_SUCCESS);
+	fclose(f);
+	fail_unless(strcmp(cfg_getstr(cfg, "string"), "") == 0);
+	cfg_free(cfg);
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */


### PR DESCRIPTION
This fixes the round-trip case where an empty string is given in a cfg file, and a new cfg file is generated (possibly with unrelated changes to other options) with the intention of later using it as input.

Without these changes the above is broken when the string option has a default value.
