### PR TITLE
Avoid clobbering CFGF_RESET when cfg_setmulti fails

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -921,6 +921,8 @@ DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues,
 		cfg_free_value(opt);
 		opt->nvalues = old.nvalues;
 		opt->values = old.values;
+		opt->flags &= ~CFGF_RESET;
+		opt->flags |= old.flags & CFGF_RESET;
 
 		return CFG_FAIL;
 	}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,9 +22,6 @@ TESTS            += empty_string
 TESTS            += setopt_ptr
 TESTS            += setmulti_reset
 
-XFAIL_TESTS       =
-XFAIL_TESTS      += setmulti_reset
-
 check_PROGRAMS    = $(TESTS)
 
 DEFS              = -DSRC_DIR='"$(srcdir)"'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,6 +20,10 @@ TESTS            += ignore_parm
 TESTS            += annotate
 TESTS            += empty_string
 TESTS            += setopt_ptr
+TESTS            += setmulti_reset
+
+XFAIL_TESTS       =
+XFAIL_TESTS      += setmulti_reset
 
 check_PROGRAMS    = $(TESTS)
 

--- a/tests/setmulti_reset.c
+++ b/tests/setmulti_reset.c
@@ -1,0 +1,35 @@
+#include "check_confuse.h"
+
+int main(void)
+{
+	cfg_opt_t opts[] = {
+		CFG_INT_LIST("int", "{1,2}", CFGF_NONE),
+		CFG_END()
+	};
+
+	/* Calling cfg_setopt after cfg_init should not append to the list. */
+	cfg_t *cfg = cfg_init(opts, 0);
+	fail_unless(cfg_size(cfg, "int") == 2);
+	fail_unless(cfg_setopt(cfg, cfg_getopt(cfg, "int"), "3"));
+	fail_unless(cfg_size(cfg, "int") == 1);
+	cfg_free(cfg);
+
+	/* Not even if you first attempt to use cfg_setmulti with bad input. */
+	cfg = cfg_init(opts, 0);
+	char *bad[] = { "bad" };
+	fail_unless(cfg_size(cfg, "int") == 2);
+	fail_unless(cfg_setmulti(cfg, "int", 1, bad) == CFG_FAIL);
+	fail_unless(cfg_size(cfg, "int") == 2);
+	fail_unless(cfg_setopt(cfg, cfg_getopt(cfg, "int"), "3"));
+	fail_unless(cfg_size(cfg, "int") == 1);
+	cfg_free(cfg);
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */


### PR DESCRIPTION
It is desirable to fail gracefully and leave the configuration unaffected by imperfect input. Remember that cfg_setmulti is the heart of the cli example and needs to fail as gracefully as possible since it is used to parse end user input.