### PR TITLE
Add modified flag, and selective printing

### DIFF
--- a/src/confuse.h
+++ b/src/confuse.h
@@ -233,6 +233,17 @@ typedef enum { cfg_false, cfg_true } cfg_bool_t;
 /** Error reporting function. */
 typedef void (*cfg_errfunc_t)(cfg_t *cfg, const char *fmt, va_list ap);
 
+/** Print filter function.
+ *
+ * @param cfg The configuration file context that opt belongs to.
+ * @param opt The configuration option that is about to be printed, or not.
+ * @return Zero if opt should be printed, non-zero if it should be filtered
+ * out.
+ *
+ * @see cfg_set_print_filter_func()
+ */
+typedef int (*cfg_print_filter_func_t)(cfg_t *cfg, cfg_opt_t *opt);
+
 /** Data structure holding information about a "section". Sections can
  * be nested. A section has a list of options (strings, numbers,
  * booleans or other sections) grouped together.
@@ -252,6 +263,7 @@ struct cfg_t {
 				 * cfg_set_error_function) is called for
 				 * any error message. */
 	cfg_searchpath_t *path;	/**< Linked list of directories to search */
+	cfg_print_filter_func_t pff; /**< Printing filter function */
 };
 
 /** Data structure holding the value of a fundamental option value.
@@ -1335,6 +1347,21 @@ DLLIMPORT cfg_print_func_t __export cfg_opt_set_print_func(cfg_opt_t *opt, cfg_p
  * @see cfg_print_func_t
  */
 DLLIMPORT cfg_print_func_t __export cfg_set_print_func(cfg_t *cfg, const char *name, cfg_print_func_t pf);
+
+/** Install a user-defined print filter function. This callback is
+ * called for each option when printing cfg, or something above cfg
+ * if cfg is a section in some parent cfg. When cfg (or something
+ * above cfg) is printed, this filter is also inherited to child
+ * sections unless the child section has its own print filter.
+ *
+ * @param cfg The configuration file context.
+ * @param pff The print filter callback function.
+ *
+ * @return The old print filter function is returned.
+ *
+ * @see cfg_print_filter_func_t
+ */
+DLLIMPORT cfg_print_filter_func_t __export cfg_set_print_filter_func(cfg_t *cfg, cfg_print_filter_func_t pff);
 
 /** Register a validating callback function for an option.
  *

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -99,6 +99,7 @@ typedef enum cfg_type_t cfg_type_t;
 #define CFGF_DEPRECATED     512  /**< option is deprecated and should be ignored. */
 #define CFGF_DROP           1024 /**< option should be dropped after parsing */
 #define CFGF_COMMENTS       2048 /**< Enable option annotation/comments support */
+#define CFGF_MODIFIED       4096 /**< option has been changed from its default value */
 
 /** Return codes from cfg_parse(), cfg_parse_boolean(), and cfg_set*() functions. */
 #define CFG_SUCCESS     0

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,7 @@ TESTS            += annotate
 TESTS            += empty_string
 TESTS            += setopt_ptr
 TESTS            += setmulti_reset
+TESTS            += print_filter
 
 check_PROGRAMS    = $(TESTS)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,6 +22,7 @@ TESTS            += empty_string
 TESTS            += setopt_ptr
 TESTS            += setmulti_reset
 TESTS            += print_filter
+TESTS            += modified_flag
 
 check_PROGRAMS    = $(TESTS)
 

--- a/tests/modified_flag.c
+++ b/tests/modified_flag.c
@@ -1,0 +1,272 @@
+#include "check_confuse.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int parse_ptr(cfg_t *cfg, cfg_opt_t *opt,
+		     const char *value, void *result)
+{
+	char *ptr = strdup(value);
+	if (!ptr)
+		return -1;
+
+	*(void **)result = ptr;
+	return 0;
+}
+
+static int is_set(cfg_t *cfg, const char *name, int flags)
+{
+	cfg_opt_t *opt = cfg_getopt(cfg, name);
+	if (!opt)
+		return -1;
+	return !!(opt->flags & flags);
+}
+
+int main(void)
+{
+	cfg_opt_t sub[] = {
+		CFG_INT_LIST("int", "{0,1,2}", CFGF_NONE),
+		CFG_INT_LIST("nodef", NULL, CFGF_NONE),
+		CFG_FLOAT("float", 42.17, CFGF_NONE),
+		CFG_BOOL("bool", cfg_true, CFGF_NONE),
+		CFG_STR("str", "hello", CFGF_NODEFAULT),
+		CFG_PTR_CB("ptr", "dummy", CFGF_NONE, parse_ptr, free),
+		CFG_END()
+	};
+	cfg_opt_t opts[] = {
+		CFG_INT_LIST("int", "{0,1,2}", CFGF_NONE),
+		CFG_INT_LIST("nodef", NULL, CFGF_NONE),
+		CFG_FLOAT("float", 17.42, CFGF_NONE),
+		CFG_BOOL("bool", cfg_true, CFGF_NONE),
+		CFG_STR("str", "hello", CFGF_NONE),
+		CFG_SEC("sub", sub, CFGF_NONE),
+		CFG_PTR_CB("ptr", "dummy", CFGF_NONE, parse_ptr, free),
+		CFG_END()
+	};
+
+	cfg_t *cfg = cfg_init(opts, 0);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_parse_buf(cfg, "int = {3,4}") == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_parse_buf(cfg, "nodef = {}") == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_parse_buf(cfg, "float = 3.14") == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	cfg_free(cfg);
+	cfg = cfg_init(opts, 0);
+	fail_unless(cfg_setnint(cfg, "nodef", 1, 1) == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_setbool(cfg, "bool", cfg_true) == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_setfloat(cfg, "sub|float", 2.718) == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_setbool(cfg, "sub|bool", cfg_true) == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	cfg_free(cfg);
+	cfg = cfg_init(opts, 0);
+	fail_unless(cfg_parse_buf(cfg, "sub { bool = true }") == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_parse_buf(cfg, "sub { str = hello }") == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	char *bad_ints[] = { "1", "a" };
+	fail_unless(cfg_setmulti(cfg, "int", 2, bad_ints) == CFG_FAIL);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	char *good_ints[] = { "1", "2" };
+	fail_unless(cfg_setmulti(cfg, "int", 2, good_ints) == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 0);
+
+	fail_unless(cfg_setmulti(cfg, "sub|ptr", 1, good_ints) == CFG_SUCCESS);
+
+	fail_unless(is_set(cfg, "int", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "bool", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "str", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "ptr", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|int", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|nodef", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|float", CFGF_MODIFIED) == 0);
+	fail_unless(is_set(cfg, "sub|bool", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|str", CFGF_MODIFIED) == 1);
+	fail_unless(is_set(cfg, "sub|ptr", CFGF_MODIFIED) == 1);
+
+	cfg_free(cfg);
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/print_filter.c
+++ b/tests/print_filter.c
@@ -1,0 +1,70 @@
+#include "check_confuse.h"
+#include <stdio.h>
+#include <string.h>
+
+static int no_foo(cfg_t *cfg, cfg_opt_t *opt)
+{
+	return !strncmp(cfg_opt_name(opt), "foo-", 4);
+}
+
+static int no_bar(cfg_t *cfg, cfg_opt_t *opt)
+{
+	return !strncmp(cfg_opt_name(opt), "bar-", 4);
+}
+
+int main(void)
+{
+	cfg_opt_t sub[] = {
+		CFG_INT_LIST("bar-int", "{0,1,2}", CFGF_NONE),
+		CFG_INT_LIST("foo-int", NULL, CFGF_NONE),
+		CFG_BOOL("bar-bool", cfg_false, CFGF_NONE),
+		CFG_FLOAT("foo-float", 2.718, CFGF_NONE),
+		CFG_STR("gazonk-string", NULL, CFGF_NONE),
+		CFG_END()
+	};
+	cfg_opt_t opts[] = {
+		CFG_INT_LIST("foo-int", "{0,1,2}", CFGF_NONE),
+		CFG_INT_LIST("bar-int", NULL, CFGF_NONE),
+		CFG_BOOL("foo-bool", cfg_true, CFGF_NONE),
+		CFG_FLOAT("bar-float", 3.14, CFGF_NONE),
+		CFG_STR("gazonk-string", "foobar", CFGF_NONE),
+		CFG_SEC("sub", sub, CFGF_NONE),
+		CFG_END()
+	};
+	char buf[200]; /* should be enough */
+	FILE *f;
+
+	cfg_t *cfg = cfg_init(opts, 0);
+
+	cfg_set_print_filter_func(cfg, no_foo);
+	f = fmemopen(buf, sizeof(buf), "w+");
+	fail_unless(f != NULL);
+	cfg_print(cfg, f);
+	fclose(f);
+
+	fprintf(stderr, "no_foo filter:\n%s", buf);
+	fail_unless(strstr(buf, "foo-") == NULL);
+	fail_unless(strstr(buf, "bar-") != NULL);
+
+	cfg_set_print_filter_func(cfg, no_bar);
+	f = fmemopen(buf, sizeof(buf), "w+");
+	fail_unless(f != NULL);
+	cfg_print(cfg, f);
+	fclose(f);
+
+	fprintf(stderr, "----\n");
+	fprintf(stderr, "no_bar filter:\n%s", buf);
+	fail_unless(strstr(buf, "foo-") != NULL);
+	fail_unless(strstr(buf, "bar-") == NULL);
+
+	cfg_free(cfg);
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */


### PR DESCRIPTION
My use case is a somewhat big config file where not all options are applicable in all cases. The program is also able to modify options at run-time, and I would like to be able to sanely implement a save-config function that does not expose a lot of unrelated config options for that particular instance.

I came up with these changes. There are naturally more than one way to solve "my" use case, but I think this is a good way since the API is left pretty much untouched which is a good thing for all others that are not necessarily interested in filtering or options that may or may not be modified.