### PR TITLE
RFC: cfg_getopt multi sub-section awareness

### DIFF
--- a/examples/cli.c
+++ b/examples/cli.c
@@ -182,8 +182,7 @@ static const char *subset(int argc, char *argv[])
 
 static const char *create(int argc, char *argv[])
 {
-	int ret;
-	char *buf;
+	cfg_opt_t *opt;
 
 	if (argc != 2)
 		return "Need one arg\n";
@@ -191,15 +190,8 @@ static const char *create(int argc, char *argv[])
 	if (cfg_gettsec(cfg, "sub", argv[1]))
 		return "Section exists already\n";
 
-	buf = malloc(strlen(argv[1]) + 20);
-	if (!buf)
-		return NULL;
-
-	sprintf(buf, "sub %s {}\n", argv[1]);
-	ret = cfg_parse_buf(cfg, buf) != CFG_SUCCESS;
-	free(buf);
-
-	if (ret)
+	opt = cfg_getopt(cfg, "sub");
+	if (!opt || !cfg_setopt(cfg, opt, argv[1]))
 		return "Failure\n";
 
 	return "OK\n";

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ TESTS            += section_title_dupes
 TESTS            += single_title_sections
 TESTS            += section_remove
 TESTS            += section_add
+TESTS            += section_getopt
 TESTS            += quote_before_print
 TESTS            += include
 TESTS            += searchpath

--- a/tests/section_getopt.c
+++ b/tests/section_getopt.c
@@ -31,6 +31,7 @@ int main(void)
 
 	int rc;
 	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+	cfg_t *sec;
 
 	fail_unless(cfg);
 
@@ -49,11 +50,37 @@ int main(void)
 	fail_unless(cfg_getint(cfg, "multi-title-no-dupes=name1|int") == 41);
 	fail_unless(cfg_getint(cfg, "multi-title-no-dupes=name2|int") == 42);
 	fail_unless(cfg_getint(cfg, "multi-title-no-dupes=name3|int") == 43);
+	sec = cfg_getsec(cfg, "single");
+	fail_unless(cfg_getint(sec, "int") == 11);
+	sec = cfg_getsec(cfg, "multi=0");
+	fail_unless(cfg_getint(sec, "int") == 21);
+	sec = cfg_getsec(cfg, "multi=1");
+	fail_unless(cfg_getint(sec, "int") == 22);
+	sec = cfg_getsec(cfg, "multi=2");
+	fail_unless(cfg_getint(sec, "int") == 23);
+	sec = cfg_getsec(cfg, "multi-title=name");
+	fail_unless(cfg_getint(sec, "int") == 31);
+	sec = cfg_getsec(cfg, "multi-title=odd");
+	fail_unless(cfg_getint(sec, "int") == 32);
+	sec = cfg_getsec(cfg, "multi-title='\\'a-very\\'silly|option\\\\title'");
+	fail_unless(cfg_getint(sec, "int") == 1);
+	sec = cfg_getsec(cfg, "multi-title-no-dupes=name1");
+	fail_unless(cfg_getint(sec, "int") == 41);
+	sec = cfg_getsec(cfg, "multi-title-no-dupes=name2");
+	fail_unless(cfg_getint(sec, "int") == 42);
+	sec = cfg_getsec(cfg, "multi-title-no-dupes=name3");
+	fail_unless(cfg_getint(sec, "int") == 43);
 
 	/* for backwards compat */
 	fail_unless(cfg_getint(cfg, "multi|int") == 21);
 	fail_unless(cfg_getint(cfg, "multi-title|int") == 31);
 	fail_unless(cfg_getint(cfg, "multi-title-no-dupes|int") == 41);
+	sec = cfg_getsec(cfg, "multi");
+	fail_unless(cfg_getint(sec, "int") == 21);
+	sec = cfg_getsec(cfg, "multi-title");
+	fail_unless(cfg_getint(sec, "int") == 31);
+	sec = cfg_getsec(cfg, "multi-title-no-dupes");
+	fail_unless(cfg_getint(sec, "int") == 41);
 
 	/* expected failures */
 	fail_unless(cfg_getopt(cfg, "single=0|int") == NULL);
@@ -62,6 +89,12 @@ int main(void)
 	fail_unless(cfg_getopt(cfg, "multi-title=bad|int") == NULL);
 	fail_unless(cfg_getopt(cfg, "multi-title-no-dupes=0|int") == NULL);
 	fail_unless(cfg_getopt(cfg, "multi-title-no-dupes=bad|int") == NULL);
+	fail_unless(cfg_getsec(cfg, "single=0") == NULL);
+	fail_unless(cfg_getsec(cfg, "multi=4") == NULL);
+	fail_unless(cfg_getsec(cfg, "multi-title=0") == NULL);
+	fail_unless(cfg_getsec(cfg, "multi-title=bad") == NULL);
+	fail_unless(cfg_getsec(cfg, "multi-title-no-dupes=0") == NULL);
+	fail_unless(cfg_getsec(cfg, "multi-title-no-dupes=bad") == NULL);
 
 	cfg_free(cfg);
 

--- a/tests/section_getopt.c
+++ b/tests/section_getopt.c
@@ -1,0 +1,76 @@
+#include "check_confuse.h"
+#include <string.h>
+
+int main(void)
+{
+	static cfg_opt_t sub_opts[] = {
+		CFG_INT("int", 1, CFGF_NONE),
+		CFG_END()
+	};
+
+	cfg_opt_t opts[] = {
+		CFG_SEC("single", sub_opts, CFGF_NONE),
+		CFG_SEC("multi", sub_opts, CFGF_MULTI),
+		CFG_SEC("multi-title", sub_opts, CFGF_TITLE | CFGF_MULTI),
+		CFG_SEC("multi-title-no-dupes", sub_opts,
+			CFGF_TITLE | CFGF_MULTI | CFGF_NO_TITLE_DUPES),
+		CFG_END()
+	};
+
+	const char *config_data =
+		"single { int = 11 }\n"
+		"multi { int = 21 }\n"
+		"multi { int = 22 }\n"
+		"multi { int = 23 }\n"
+		"multi-title name { int = 30 }\n"
+		"multi-title name { int = 31 }\n"
+		"multi-title odd  { int = 32 }\n"
+		"multi-title-no-dupes name1 { int = 41 }\n"
+		"multi-title-no-dupes name2 { int = 42 }\n"
+		"multi-title-no-dupes name3 { int = 43 }\n";
+
+	int rc;
+	cfg_t *cfg = cfg_init(opts, CFGF_NONE);
+
+	fail_unless(cfg);
+
+	rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(rc == CFG_SUCCESS);
+
+	fail_unless(cfg_addtsec(cfg, "multi-title", "'a-very'silly|option\\title") != NULL);
+
+	fail_unless(cfg_getint(cfg, "single|int") == 11);
+	fail_unless(cfg_getint(cfg, "multi=0|int") == 21);
+	fail_unless(cfg_getint(cfg, "multi=1|int") == 22);
+	fail_unless(cfg_getint(cfg, "multi=2|int") == 23);
+	fail_unless(cfg_getint(cfg, "multi-title=name|int") == 31);
+	fail_unless(cfg_getint(cfg, "multi-title=odd|int") == 32);
+	fail_unless(cfg_getint(cfg, "multi-title='\\'a-very\\'silly|option\\\\title'|int") == 1);
+	fail_unless(cfg_getint(cfg, "multi-title-no-dupes=name1|int") == 41);
+	fail_unless(cfg_getint(cfg, "multi-title-no-dupes=name2|int") == 42);
+	fail_unless(cfg_getint(cfg, "multi-title-no-dupes=name3|int") == 43);
+
+	/* for backwards compat */
+	fail_unless(cfg_getint(cfg, "multi|int") == 21);
+	fail_unless(cfg_getint(cfg, "multi-title|int") == 31);
+	fail_unless(cfg_getint(cfg, "multi-title-no-dupes|int") == 41);
+
+	/* expected failures */
+	fail_unless(cfg_getopt(cfg, "single=0|int") == NULL);
+	fail_unless(cfg_getopt(cfg, "multi=4|int") == NULL);
+	fail_unless(cfg_getopt(cfg, "multi-title=0|int") == NULL);
+	fail_unless(cfg_getopt(cfg, "multi-title=bad|int") == NULL);
+	fail_unless(cfg_getopt(cfg, "multi-title-no-dupes=0|int") == NULL);
+	fail_unless(cfg_getopt(cfg, "multi-title-no-dupes=bad|int") == NULL);
+
+	cfg_free(cfg);
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/section_remove.c
+++ b/tests/section_remove.c
@@ -44,6 +44,18 @@ int main(void)
 
 	cfg_free(cfg);
 
+	cfg = cfg_init(opts, CFGF_NONE);
+	fail_unless(cfg);
+
+	rc = cfg_parse_buf(cfg, config_data);
+	fail_unless(rc == CFG_SUCCESS);
+
+	cfg_rmsec(cfg, "section=title_two");
+	fail_unless(cfg_size(cfg, "section") == 1);
+	fail_unless(strcmp(cfg_title(cfg_getnsec(cfg, "section", 0)), "title_one") == 0);
+
+	cfg_free(cfg);
+
 	return 0;
 }
 


### PR DESCRIPTION
Hi!
This is more of a request for comments than a "normal" pull-request. That said, I would not be sorry if it was accepted as-is... The "status" is RFC, because this introduces a minor (if you ask me) incompatible change, as can be seen by the tweaks needed in the test suite. That incompatibility could perhaps be handled with some alternate notation? I didn't want to come up with something on my own, since I do not have a clear picture of the exact naming rules and what a non-invasive and non-ambiguous notation would be.

What I mean by alternate notation, is that perhaps instead of "sub|title|option", it could be "sub+title|option" or something along those lines, but + can clearly be a part of any option name, so it is not quite as simple as that...

The cli patch is really unrelated, and I should perhaps have removed it, but I didn't bother. The other patch description has more details on the more interesting change. That said, the cli example can be used to test this, try e.g. "create foo" followed by "set sub|foo|int 2" (instead of "subset foo int 2").