### PR TITLE
fix `cfg_t *cfg_addtsec()`: can't return the pointer to the section if already exists.

### DIFF
--- a/examples/addsec.c
+++ b/examples/addsec.c
@@ -66,10 +66,12 @@ int main(void)
 	/* Add a new section */
 	sec = cfg_addtsec(cfg, "argument", "two");
 	cfg_setstr(sec, "value", "foo");
+	/* Add an existing section */
+	sec = cfg_addtsec(cfg, "argument", "three");
+	cfg_setstr(sec, "value", "gazonk!!");
 	print_message();
 
 	cfg_free(cfg);
 
 	return 0;
-
 }

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -2313,11 +2313,13 @@ DLLIMPORT int cfg_addlist(cfg_t *cfg, const char *name, unsigned int nvalues, ..
 
 DLLIMPORT cfg_t *cfg_addtsec(cfg_t *cfg, const char *name, const char *title)
 {
+	cfg_t *sec;
 	cfg_opt_t *opt;
 	cfg_value_t *val;
 
-	if (cfg_gettsec(cfg, name, title))
-		return NULL;
+	sec = cfg_gettsec(cfg, name, title);
+	if (sec)
+		return sec;
 
 	opt = cfg_getopt(cfg, name);
 	if (!opt) {


### PR DESCRIPTION
This is related to #158, and attempt to fix.