### PR TITLE
Pass test suite with sanitizers

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -671,7 +671,8 @@ static cfg_opt_t *cfg_dupopt_array(cfg_opt_t *opts)
 	if (!dupopts)
 		return NULL;
 
-	memcpy(dupopts, opts, n * sizeof(cfg_opt_t));
+	if (n)
+		memcpy(dupopts, opts, n * sizeof(cfg_opt_t));
 
 	for (i = 0; i < n; i++) {
 		/* Clear dynamic ptrs, protecting the original on failure */

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -33,6 +33,7 @@
 # include <unistd.h>
 #endif
 #include <ctype.h>
+#include <limits.h>
 
 #ifdef HAVE_SYS_STAT_H
 # include <sys/stat.h>
@@ -260,7 +261,7 @@ static long int cfg_opt_gettsecidx(cfg_opt_t *opt, const char *title)
 }
 
 static cfg_opt_t *cfg_getopt_secidx(cfg_t *cfg, const char *name,
-				    long int *index)
+				    unsigned int *index)
 {
 	cfg_opt_t *opt = NULL;
 	cfg_t *sec = cfg;
@@ -312,13 +313,14 @@ static cfg_opt_t *cfg_getopt_secidx(cfg_t *cfg, const char *name,
 				break;
 			}
 
-			i = strtol(title, &endptr, 0);
-			if (*endptr != '\0')
+			errno = 0;
+			i = strtoul(title, &endptr, 0);
+			if (*endptr != '\0' || errno || i > UINT_MAX)
 				i = -1;
 		} while(0);
 
 		if (index)
-			*index = i;
+			*index = i >= 0 ? i : UINT_MAX;
 
 		sec = i >= 0 ? cfg_opt_getnsec(opt, i) : NULL;
 		if (!sec && !is_set(CFGF_IGNORE_UNKNOWN, cfg->flags)) {
@@ -595,7 +597,7 @@ DLLIMPORT cfg_t *cfg_gettsec(cfg_t *cfg, const char *name, const char *title)
 DLLIMPORT cfg_t *cfg_getsec(cfg_t *cfg, const char *name)
 {
 	cfg_opt_t *opt;
-	long int index;
+	unsigned int index;
 
 	opt = cfg_getopt_secidx(cfg, name, &index);
 	return cfg_opt_getnsec(opt, index);
@@ -2378,7 +2380,7 @@ DLLIMPORT int cfg_rmnsec(cfg_t *cfg, const char *name, unsigned int index)
 DLLIMPORT int cfg_rmsec(cfg_t *cfg, const char *name)
 {
 	cfg_opt_t *opt;
-	long int index;
+	unsigned int index;
 
 	opt = cfg_getopt_secidx(cfg, name, &index);
 	return cfg_opt_rmnsec(opt, index);

--- a/tests/empty_string.c
+++ b/tests/empty_string.c
@@ -28,6 +28,12 @@ int main(void)
 	fail_unless(cfg_print(cfg, f) == CFG_SUCCESS);
 	cfg_free(cfg);
 
+#if defined(__has_feature)
+# if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
+	/* Skip check since fmemopen(2) is broken with sanitizers, see
+	 *   https://github.com/google/sanitizers/issues/628
+	 */
+# else
 	/*
 	 * try to reload the generated temporary config file to check
 	 * that the default is indeed overridden by an empty string
@@ -36,9 +42,12 @@ int main(void)
 	fail_unless(cfg != NULL);
 	fail_unless(fseek(f, 0L, SEEK_SET) == 0);
 	fail_unless(cfg_parse_fp(cfg, f) == CFG_SUCCESS);
-	fclose(f);
 	fail_unless(strcmp(cfg_getstr(cfg, "string"), "") == 0);
 	cfg_free(cfg);
+# endif
+#endif
+
+	fclose(f);
 
 	return 0;
 }

--- a/tests/empty_string.c
+++ b/tests/empty_string.c
@@ -25,7 +25,7 @@ int main(void)
 	fail_unless(strcmp(cfg_getstr(cfg, "string"), "") == 0);
 	f = fmemopen(buf, sizeof(buf), "w+");
 	fail_unless(f != NULL);
-	cfg_print(cfg, f);
+	fail_unless(cfg_print(cfg, f) == CFG_SUCCESS);
 	cfg_free(cfg);
 
 	/*
@@ -33,7 +33,8 @@ int main(void)
 	 * that the default is indeed overridden by an empty string
 	 */
 	cfg = cfg_init(opts, 0);
-	fseek(f, 0L, SEEK_SET);
+	fail_unless(cfg != NULL);
+	fail_unless(fseek(f, 0L, SEEK_SET) == 0);
 	fail_unless(cfg_parse_fp(cfg, f) == CFG_SUCCESS);
 	fclose(f);
 	fail_unless(strcmp(cfg_getstr(cfg, "string"), "") == 0);

--- a/tests/print_filter.c
+++ b/tests/print_filter.c
@@ -39,7 +39,7 @@ int main(void)
 	cfg_set_print_filter_func(cfg, no_foo);
 	f = fmemopen(buf, sizeof(buf), "w+");
 	fail_unless(f != NULL);
-	cfg_print(cfg, f);
+	fail_unless(cfg_print(cfg, f) == CFG_SUCCESS);
 	fclose(f);
 
 	fprintf(stderr, "no_foo filter:\n%s", buf);
@@ -49,7 +49,7 @@ int main(void)
 	cfg_set_print_filter_func(cfg, no_bar);
 	f = fmemopen(buf, sizeof(buf), "w+");
 	fail_unless(f != NULL);
-	cfg_print(cfg, f);
+	fail_unless(cfg_print(cfg, f) == CFG_SUCCESS);
 	fclose(f);
 
 	fprintf(stderr, "----\n");

--- a/tests/print_filter.c
+++ b/tests/print_filter.c
@@ -42,6 +42,12 @@ int main(void)
 	fail_unless(cfg_print(cfg, f) == CFG_SUCCESS);
 	fclose(f);
 
+#if defined(__has_feature)
+# if __has_feature(memory_sanitizer)
+	/* Skip check since fmemopen(2) is broken with sanitizers, see
+	 *   https://github.com/google/sanitizers/issues/628
+	 */
+# else
 	fprintf(stderr, "no_foo filter:\n%s", buf);
 	fail_unless(strstr(buf, "foo-") == NULL);
 	fail_unless(strstr(buf, "bar-") != NULL);
@@ -56,6 +62,8 @@ int main(void)
 	fprintf(stderr, "no_bar filter:\n%s", buf);
 	fail_unless(strstr(buf, "foo-") != NULL);
 	fail_unless(strstr(buf, "bar-") == NULL);
+# endif
+#endif
 
 	cfg_free(cfg);
 


### PR DESCRIPTION
Pass the testsuite when build with sanitizers, e.g. `CFLAGS=-O1 -g -fsanitize=address -fsanitize-address-use-after-scope -fsanitize-address-use-after-return=always -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=nullability -fsanitize=implicit-conversion -fsanitize=integer -fsanitize=float-divide-by-zero -fsanitize=local-bounds`:


* Avoid calling memcpy with NULL pointer and length 0
  Found by running the test suite with undefined behavior sanitizer:

      confuse.c:674:18: runtime error: null pointer passed as argument 2, which is declared to never be null
      /usr/include/string.h:44:28: note: nonnull attribute specified here
          #0 0x55f77032e601 in cfg_dupopt_array ./libconfuse/src/confuse.c:674:2
          https://github.com/libconfuse/libconfuse/issues/1 0x55f770328227 in cfg_setopt ./libconfuse/src/confuse.c:1063:25
          https://github.com/libconfuse/libconfuse/pull/2 0x55f77032f537 in cfg_init_defaults ./libconfuse/src/confuse.c:861:4
          https://github.com/libconfuse/libconfuse/issues/3 0x55f770335dbb in cfg_init ./libconfuse/src/confuse.c:1877:2
          https://github.com/libconfuse/libconfuse/issues/4 0x55f770321ff7 in main ./libconfuse/tests/keyval.c:50:8
          https://github.com/libconfuse/libconfuse/issues/5 0x7f4bba429209 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
          https://github.com/libconfuse/libconfuse/pull/6 0x7f4bba4292bb in __libc_start_main csu/../csu/libc-start.c:389:3
          https://github.com/libconfuse/libconfuse/pull/7 0x55f7702623c0 in _start (./libconfuse/tests/keyval+0x3a3c0)

* Avoid implicit integer conversions
  
      confuse.c:601:30: runtime error: implicit conversion from type 'long' of value -1 (64-bit, signed) to type 'unsigned int' changed the value to 4294967295 (32-bit, unsigned)
          #0 0x55bb8fcd6f30 in cfg_getsec ./libconfuse/src/confuse.c:601:30
          https://github.com/libconfuse/libconfuse/issues/1 0x55bb8fcd23e4 in main ./libconfuse/tests/section_getopt.c:92:2
          https://github.com/libconfuse/libconfuse/pull/2 0x7f380da29209 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
          https://github.com/libconfuse/libconfuse/issues/3 0x7f380da292bb in __libc_start_main csu/../csu/libc-start.c:389:3
          https://github.com/libconfuse/libconfuse/issues/4 0x55bb8fc123b0 in _start (./libconfuse/tests/section_getopt+0x3b3b0)

* tests: check additional calls and results

* tests: skip test with broken fmemopen under sanitizers
  fmemopen(2) is broken with address and memory sanitizer, see https://github.com/google/sanitizers/issues/628.