### PR TITLE
examples/ftpconf.c: fix type cast in conf_parse_acb()

### DIFF
--- a/examples/ftpconf.c
+++ b/examples/ftpconf.c
@@ -28,11 +28,11 @@ int conf_alias(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
 int conf_parse_acb(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
 	if (strcmp(value, "yes") == 0)
-		*(int *)result = ACB_YES;
+		*(long int *)result = ACB_YES;
 	else if (strcmp(value, "no") == 0)
-		*(int *)result = ACB_NO;
+		*(long int *)result = ACB_NO;
 	else if (strcmp(value, "ask") == 0)
-		*(int *)result = ACB_ASK;
+		*(long int *)result = ACB_ASK;
 	else {
 		cfg_error(cfg, "invalid value for option '%s': %s", cfg_opt_name(opt), value);
 		return -1;


### PR DESCRIPTION
The conf_parse_acb() callback is passed a pointer to long int, not merely int. That the callback ends up only initializing half of the pointed-to-value can easily be seen by just running the example a few times, leading to output such as

  auto-create-bookmark = 140720308486147

  auto-create-bookmark = 140724603453443

etc.

I think one could (should?) change the .parsecb member to an anonymous union like

union {
  cfg_callback_t parsecb;
  cfg_int_callback_t parsecb_int;
  cfg_float_callback_t parsecb_float;
};

with the latter two being of course

typedef int (*cfg_int_callback_t)(cfg_t *cfg, cfg_opt_t *opt, const char *value, long int *result); typedef int (*cfg_float_callback_t)(cfg_t *cfg, cfg_opt_t *opt, const char *value, double *result);

update the __CFG_INT and __CFG_FLOAT macros to initialize the appropriate union member, and change the callers in cfg_setopt() to invoke the appropriate type-safe callback. [STR is more complicated, so I'd leave that alone at first].

This change would be ABI, but not API, compatible, but all users would have to do would be to update the signature of their callbacks and in return allow them to get rid of error-prone casts like these.