### PR TITLE
Add CFGT_RAWSEC: capture a section body verbatim

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -68,6 +68,9 @@ extern void cfg_scan_fp_begin(FILE *fp);
 extern void cfg_scan_fp_end(void);
 extern void cfg_raw_begin(void);
 extern char *cfg_raw_end(void);
+extern int  cfg_raw_active(void);
+extern size_t cfg_raw_tell(void);
+extern void cfg_raw_seek(size_t pos);
 
 static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t *force_opt);
 static void cfg_free_opt_array(cfg_opt_t *opts);
@@ -875,6 +878,30 @@ static void cfg_init_defaults(cfg_t *cfg)
 
 static cfg_opt_t rawsec_no_opts[] = { CFG_END() };
 
+/* Append an include() function to a section's (already duplicated) option
+ * array, so that CFGF_USE_INCLUDE_FUNCTION sections gain include support. */
+static int cfg_section_add_include(cfg_t *sec)
+{
+	int num = cfg_numopts(sec->opts);
+	cfg_opt_t *opts;
+
+	opts = reallocarray(sec->opts, num + 2, sizeof(cfg_opt_t));
+	if (!opts)
+		return CFG_FAIL;
+
+	sec->opts = opts;
+	memset(&sec->opts[num], 0, sizeof(cfg_opt_t));
+	sec->opts[num].name = strdup("include");
+	if (!sec->opts[num].name)
+		return CFG_FAIL;
+	sec->opts[num].type = CFGT_FUNC;
+	sec->opts[num].func = &cfg_include;
+
+	memset(&sec->opts[num + 1], 0, sizeof(cfg_opt_t)); /* new CFG_END() */
+
+	return CFG_SUCCESS;
+}
+
 DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 {
 	cfg_value_t *val = NULL;
@@ -1081,6 +1108,10 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 				free(val->section);
 				return NULL;
 			}
+
+			if (is_set(CFGF_USE_INCLUDE_FUNCTION, opt->flags) &&
+			    cfg_section_add_include(val->section) != CFG_SUCCESS)
+				return NULL;
 		}
 		if (!is_set(CFGF_DEFINIT, opt->flags))
 			cfg_init_defaults(val->section);
@@ -1121,7 +1152,8 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 				return NULL;
 			}
 
-			/* A raw section carries no sub-options */
+			/* A raw section carries no sub-options, unless it opts in
+			 * to include() via CFGF_USE_INCLUDE_FUNCTION. */
 			val->section->opts = cfg_dupopt_array(rawsec_no_opts);
 			if (!val->section->opts) {
 				free(val->section->title);
@@ -1130,6 +1162,10 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 				free(val->section);
 				return NULL;
 			}
+
+			if (is_set(CFGF_USE_INCLUDE_FUNCTION, opt->flags) &&
+			    cfg_section_add_include(val->section) != CFG_SUCCESS)
+				return NULL;
 		}
 		break;
 
@@ -1358,6 +1394,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 	int ignore = 0;		/* ignore until this token, traverse parser w/o error */
 	int num_values = 0;	/* number of values found for a list option */
 	int rc;
+	size_t rawmark = 0;	/* capture offset before a func, for include() expansion */
 
 	if (force_state != -1)
 		state = force_state;
@@ -1446,6 +1483,8 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				else
 					state = 5;
 			} else if (opt->type == CFGT_FUNC) {
+				if (cfg_raw_active())
+					rawmark = cfg_raw_tell() - strlen(cfg_yylval);
 				state = 7;
 			} else {
 				state = 1;
@@ -1616,6 +1655,11 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			if (tok == ')') {
 				if (call_function(cfg, opt, &funcopt))
 					goto error;
+				/* Replace an include() call
+				 * by its expanded content
+				 * in the raw capture*/
+				if (cfg_raw_active() && opt && opt->func == cfg_include)
+					cfg_raw_seek(rawmark);
 				state = 0;
 			} else if (tok == CFGT_STR) {
 				val = cfg_addval(&funcopt);
@@ -1637,6 +1681,11 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			if (tok == ')') {
 				if (call_function(cfg, opt, &funcopt))
 					goto error;
+				/* Replace an include() call
+				 * by its expanded content
+				 * in the raw capture*/
+				if (cfg_raw_active() && opt && opt->func == cfg_include)
+					cfg_raw_seek(rawmark);
 				state = 0;
 			} else if (tok == ',') {
 				state = 8;

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -66,6 +66,8 @@ extern void cfg_yylex_destroy(void);
 extern int  cfg_lexer_include(cfg_t *cfg, const char *fname);
 extern void cfg_scan_fp_begin(FILE *fp);
 extern void cfg_scan_fp_end(void);
+extern void cfg_raw_begin(void);
+extern char *cfg_raw_end(void);
 
 static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t *force_opt);
 static void cfg_free_opt_array(cfg_opt_t *opts);
@@ -292,7 +294,7 @@ static cfg_opt_t *cfg_getopt_secidx(cfg_t *cfg, const char *name,
 			char *endptr;
 
 			opt = cfg_getopt_leaf(sec, secname);
-			if (!opt || opt->type != CFGT_SEC) {
+			if (!opt || (opt->type != CFGT_SEC && opt->type != CFGT_RAWSEC)) {
 				opt = NULL;
 				break;
 			}
@@ -374,6 +376,13 @@ DLLIMPORT const char *cfg_title(cfg_t *cfg)
 {
 	if (cfg)
 		return cfg->title;
+	return NULL;
+}
+
+DLLIMPORT const char *cfg_getraw(cfg_t *cfg)
+{
+	if (cfg)
+		return cfg->raw;
 	return NULL;
 }
 
@@ -548,7 +557,7 @@ DLLIMPORT void *cfg_getptr(cfg_t *cfg, const char *name)
 
 DLLIMPORT cfg_t *cfg_opt_getnsec(cfg_opt_t *opt, unsigned int index)
 {
-	if (!opt || opt->type != CFGT_SEC) {
+	if (!opt || (opt->type != CFGT_SEC && opt->type != CFGT_RAWSEC)) {
 		errno = EINVAL;
 		return NULL;
 	}
@@ -762,7 +771,7 @@ static void cfg_init_defaults(cfg_t *cfg)
 		if (cfg->opts[i].simple_value.ptr || is_set(CFGF_NODEFAULT, cfg->opts[i].flags))
 			continue;
 
-		if (cfg->opts[i].type != CFGT_SEC) {
+		if (cfg->opts[i].type != CFGT_SEC && cfg->opts[i].type != CFGT_RAWSEC) {
 			cfg->opts[i].flags |= CFGF_DEFINIT;
 
 			if (is_set(CFGF_LIST, cfg->opts[i].flags) || cfg->opts[i].def.parsed) {
@@ -864,6 +873,8 @@ static void cfg_init_defaults(cfg_t *cfg)
 	}
 }
 
+static cfg_opt_t rawsec_no_opts[] = { CFG_END() };
+
 DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 {
 	cfg_value_t *val = NULL;
@@ -894,7 +905,7 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		if (opt->nvalues == 0 || is_set(CFGF_MULTI, opt->flags) || is_set(CFGF_LIST, opt->flags)) {
 			val = NULL;
 
-			if (opt->type == CFGT_SEC && is_set(CFGF_TITLE, opt->flags)) {
+			if ((opt->type == CFGT_SEC || opt->type == CFGT_RAWSEC) && is_set(CFGF_TITLE, opt->flags)) {
 				unsigned int i;
 
 				/* XXX: Check if there already is a section with the same title. */
@@ -1073,6 +1084,53 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		}
 		if (!is_set(CFGF_DEFINIT, opt->flags))
 			cfg_init_defaults(val->section);
+		break;
+
+	case CFGT_RAWSEC:
+		if (is_set(CFGF_MULTI, opt->flags) || val->section == NULL) {
+			if (val->section) {
+				val->section->path = NULL; /* Global search path */
+				cfg_free(val->section);
+			}
+			val->section = calloc(1, sizeof(cfg_t));
+			if (!val->section)
+				return NULL;
+
+			val->section->name = strdup(opt->name);
+			if (!val->section->name) {
+				free(val->section);
+				return NULL;
+			}
+
+			/* The body is walked by the mini discard parser, so it must ignore. */
+			val->section->flags = cfg->flags | CFGF_IGNORE_UNKNOWN;
+			val->section->filename = cfg->filename ? strdup(cfg->filename) : NULL;
+			if (cfg->filename && !val->section->filename) {
+				free(val->section->name);
+				free(val->section);
+				return NULL;
+			}
+
+			val->section->line = cfg->line;
+			val->section->errfunc = cfg->errfunc;
+			val->section->title = value ? strdup(value) : NULL;
+			if (value && !val->section->title) {
+				free(val->section->filename);
+				free(val->section->name);
+				free(val->section);
+				return NULL;
+			}
+
+			/* A raw section carries no sub-options */
+			val->section->opts = cfg_dupopt_array(rawsec_no_opts);
+			if (!val->section->opts) {
+				free(val->section->title);
+				free(val->section->filename);
+				free(val->section->name);
+				free(val->section);
+				return NULL;
+			}
+		}
 		break;
 
 	case CFGT_BOOL:
@@ -1382,7 +1440,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				goto error;
 			}
 
-			if (opt->type == CFGT_SEC) {
+			if (opt->type == CFGT_SEC || opt->type == CFGT_RAWSEC) {
 				if (is_set(CFGF_TITLE, opt->flags))
 					state = 6;
 				else
@@ -1510,9 +1568,23 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			val->section->path = cfg->path; /* Remember global search path */
 			val->section->line = cfg->line;
 			val->section->errfunc = cfg->errfunc;
+
+			if (opt->type == CFGT_RAWSEC)
+				cfg_raw_begin();
+
 			rc = cfg_parse_internal(val->section, level + 1, -1, NULL);
-			if (rc != STATE_EOF)
+			if (rc != STATE_EOF) {
+				if (opt->type == CFGT_RAWSEC)
+					cfg_raw_end();
 				goto error;
+			}
+
+			if (opt->type == CFGT_RAWSEC) {
+				free(val->section->raw);
+				val->section->raw = strdup(cfg_raw_end());
+				if (!val->section->raw)
+					goto error;
+			}
 
 			cfg->line = val->section->line;
 			if (opt && opt->validcb && (*opt->validcb) (cfg, opt) != 0)
@@ -1593,11 +1665,11 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				state = 12; /* Section, ignore all until closing brace */
 			} else if (tok == CFGT_STR) {
 				state = 11; /* No '=' ... must be a titled section */
-			} else if (tok == '}' && force_state == 10) {
+			} else if (tok == '}') {
 				if (comment)
 					free(comment);
 
-				return STATE_CONTINUE;
+				return force_state >= 10 ? STATE_CONTINUE : STATE_EOF;
 			}
 			break;
 
@@ -1610,11 +1682,21 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			break;
 
 		case 12: /* unknown option, recursively ignore entire sub-section */
-			rc = cfg_parse_internal(cfg, level + 1, 10, NULL);
-			if (rc != STATE_CONTINUE)
-				goto error;
-			ignore = '}';
-			state = 13;
+			if (tok == '}') {
+				state = force_state >= 10 ? 15 : 0;
+				break;
+			} else if (tok == CFGT_COMMENT) {
+				state = 15;
+				rc = cfg_parse_internal(cfg, level + 1, 15, NULL);
+				if (rc != STATE_CONTINUE)
+					goto error;
+				break;
+			} else {
+				rc = cfg_parse_internal(cfg, level + 1, 10, NULL);
+				if (rc != STATE_CONTINUE)
+					goto error;
+				state = force_state >= 10 ? 15 : 0;
+			}
 			break;
 
 		case 13: /* unknown option, consume tokens silently until end of func/list */
@@ -1627,16 +1709,8 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				break;
 			}
 
-			/* Are we done with recursive ignore of sub-section? */
-			if (force_state == 10) {
-				if (comment)
-					free(comment);
-
-				return STATE_CONTINUE;
-			}
-
 			ignore = 0;
-			state = 0;
+			state = force_state >= 10 ? 15 : 0;
 			break;
 
 		case 14: /* unknown option, assuming value or start of list */
@@ -1652,13 +1726,14 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			}
 
 			ignore = 0;
-			if (force_state == 10)
-				state = 15;
-			else
-				state = 0;
+			state = force_state >= 10 ? 15 : 0;
 			break;
 
 		case 15: /* unknown option, dummy read of next parameter in sub-section */
+			if (tok == CFGT_COMMENT)
+				continue;
+			else if (tok == '}')
+				return force_state >= 10 ? STATE_CONTINUE : STATE_EOF;
 			state = 10;
 			break;
 
@@ -1946,7 +2021,7 @@ DLLIMPORT int cfg_free_value(cfg_opt_t *opt)
 		for (i = 0; i < opt->nvalues; i++) {
 			if (opt->type == CFGT_STR) {
 				free((void *)opt->values[i]->string);
-			} else if (opt->type == CFGT_SEC) {
+			} else if (opt->type == CFGT_SEC || opt->type == CFGT_RAWSEC) {
 				opt->values[i]->section->path = NULL; /* Global search path */
 				cfg_free(opt->values[i]->section);
 			} else if (opt->type == CFGT_PTR && opt->freecb && opt->values[i]->ptr) {
@@ -2019,6 +2094,8 @@ DLLIMPORT int cfg_free(cfg_t *cfg)
 		free(cfg->title);
 	if (cfg->filename)
 		free(cfg->filename);
+	if (cfg->raw)
+		free(cfg->raw);
 
 	free(cfg);
 	if (isroot)
@@ -2460,6 +2537,7 @@ DLLIMPORT int cfg_opt_nprint_var(cfg_opt_t *opt, unsigned int index, FILE *fp)
 
 	case CFGT_NONE:
 	case CFGT_SEC:
+	case CFGT_RAWSEC:
 	case CFGT_FUNC:
 	case CFGT_PTR:
 	case CFGT_COMMENT:
@@ -2502,6 +2580,18 @@ static int cfg_opt_print_pff_indent(cfg_opt_t *opt, FILE *fp,
 			cfg_print_pff_indent(sec, fp, pff, indent + 1);
 			cfg_indent(fp, indent);
 			fprintf(fp, "}\n");
+		}
+	} else if (opt->type == CFGT_RAWSEC) {
+		cfg_t *sec;
+		unsigned int i;
+
+		for (i = 0; i < cfg_opt_size(opt); i++) {
+			sec = cfg_opt_getnsec(opt, i);
+			cfg_indent(fp, indent);
+			if (is_set(CFGF_TITLE, opt->flags))
+				fprintf(fp, "%s \"%s\" {%s}\n", opt->name, cfg_title(sec), sec->raw ? sec->raw : "");
+			else
+				fprintf(fp, "%s {%s}\n", opt->name, sec->raw ? sec->raw : "");
 		}
 	} else if (opt->type != CFGT_FUNC && opt->type != CFGT_NONE) {
 		if (is_set(CFGF_LIST, opt->flags)) {

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -78,7 +78,8 @@ enum cfg_type_t {
 	CFGT_SEC,    /**< section */
 	CFGT_FUNC,   /**< function */
 	CFGT_PTR,    /**< pointer to user-defined value */
-	CFGT_COMMENT /**< comment/annotation */
+	CFGT_COMMENT,/**< comment/annotation */
+	CFGT_RAWSEC  /**< section whose body is captured verbatim as a string */
 };
 typedef enum cfg_type_t cfg_type_t;
 
@@ -265,6 +266,7 @@ struct cfg_t {
 				 * any error message. */
 	cfg_searchpath_t *path;	/**< Linked list of directories to search */
 	cfg_print_filter_func_t pff; /**< Printing filter function */
+	char *raw;		/**< Verbatim body, set for CFGT_RAWSEC sections */
 };
 
 /** Data structure holding the value of a fundamental option value.
@@ -351,6 +353,15 @@ extern const char __export confuse_author[];
  */
 #define CFG_STR(name, def, flags) \
   __CFG_STR(name, def, flags, NULL, NULL)
+
+/** Initialize a raw section option.
+ */
+#define CFG_RAWSEC(_name, _flags) { \
+	.name = _name, \
+	.type = CFGT_RAWSEC, \
+	.flags = _flags, \
+	.subopts = NULL, \
+}
 
 /** Initialize a string list option
  */
@@ -987,6 +998,13 @@ DLLIMPORT unsigned int __export cfg_size(cfg_t *cfg, const char *name);
  * should not be modified.
  */
 DLLIMPORT const char *__export cfg_title(cfg_t *cfg);
+
+/** Return the verbatim body of a raw section (CFGT_RAWSEC).
+ *
+ * @param cfg The raw section context.
+ * @return Returns the captured body, or 0 if none. Do not modify.
+ */
+DLLIMPORT const char *__export cfg_getraw(cfg_t *cfg);
 
 /** Return the name of a section.
  *

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -101,6 +101,7 @@ typedef enum cfg_type_t cfg_type_t;
 #define CFGF_COMMENTS       (1 << 11) /**< Enable option annotation/comments support */
 #define CFGF_MODIFIED       (1 << 12) /**< option has been changed from its default value */
 #define CFGF_KEYSTRVAL      (1 << 13) /**< section has free-form key=value string options created when parsing file */
+#define CFGF_USE_INCLUDE_FUNCTION (1 << 14) /**< add an include() function to the section's options */
 
 /** Return codes from cfg_parse(), cfg_parse_boolean(), and cfg_set*() functions. */
 #define CFG_SUCCESS     0

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -75,6 +75,17 @@ struct {
 } cfg_include_stack[MAX_INCLUDE_DEPTH];
 int cfg_include_stack_ptr = 0;
 
+/* Verbatim capture buffer for CFGT_RAWSEC bodies.  While capturing, every
+ * byte the scanner matches is echoed here via YY_USER_ACTION, so the body
+ * is stored exactly as written while the parser walks it as usual. */
+static int cfg_raw_capturing = 0;
+static char *cfg_raw_buf = NULL;
+static size_t cfg_raw_len = 0;
+static size_t cfg_raw_cap = 0;
+static void cfg_raw_append(const char *s, int n);
+
+#define YY_USER_ACTION if (cfg_raw_capturing) cfg_raw_append(yytext, yyleng);
+
 void cfg_scan_fp_begin(FILE *fp);
 void cfg_scan_fp_end(void);
 
@@ -316,6 +327,39 @@ void cfg_dummy_function(void)
     yyunput(0, NULL);
 }
 
+static void cfg_raw_append(const char *s, int n)
+{
+    if (cfg_raw_len + (size_t)n + 1 > cfg_raw_cap) {
+        cfg_raw_cap = (cfg_raw_len + (size_t)n + 1) * 2;
+        cfg_raw_buf = (char *)realloc(cfg_raw_buf, cfg_raw_cap);
+        assert(cfg_raw_buf);
+    }
+    memcpy(cfg_raw_buf + cfg_raw_len, s, n);
+    cfg_raw_len += n;
+}
+
+/* Start capturing the verbatim bytes of a CFGT_RAWSEC body.*/
+void cfg_raw_begin(void)
+{
+    cfg_raw_len = 0;
+    cfg_raw_capturing = 1;
+}
+
+/* Stop raw capturing and return the body.*/
+char *cfg_raw_end(void)
+{
+    cfg_raw_capturing = 0;
+    if (cfg_raw_len > 0 && cfg_raw_buf[cfg_raw_len - 1] == '}')
+        cfg_raw_len--;
+    if (!cfg_raw_buf) {
+        cfg_raw_buf = (char *)malloc(1);
+        assert(cfg_raw_buf);
+        cfg_raw_cap = 1;
+    }
+    cfg_raw_buf[cfg_raw_len] = '\0';
+    return cfg_raw_buf;
+}
+
 int cfg_lexer_include(cfg_t *cfg, const char *filename)
 {
     FILE *fp;
@@ -460,5 +504,16 @@ void cfg_scan_fp_end(void)
 	    free(cfg_qstring);
     cfg_qstring = NULL;
     qstring_index = qstring_len = 0;
+
+    /* Release the raw-capture buffer once a top-level parse is done.
+     * Guard against buffer pops that happen *during* a capture (an
+     * include() inside a raw section), which must keep the buffer. */
+    if (!cfg_raw_capturing) {
+	    if (cfg_raw_buf)
+	        free(cfg_raw_buf);
+	    cfg_raw_buf = NULL;
+	    cfg_raw_len = cfg_raw_cap = 0;
+    }
+
     cfg_yypop_buffer_state();
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -360,6 +360,25 @@ char *cfg_raw_end(void)
     return cfg_raw_buf;
 }
 
+/* Whether a raw body is currently being captured. */
+int cfg_raw_active(void)
+{
+    return cfg_raw_capturing;
+}
+
+/* Current length of the capture buffer, and truncation back to a mark;
+ * used to drop an include() call from the captured body. */
+size_t cfg_raw_tell(void)
+{
+    return cfg_raw_len;
+}
+
+void cfg_raw_seek(size_t pos)
+{
+    if (pos <= cfg_raw_len)
+        cfg_raw_len = pos;
+}
+
 int cfg_lexer_include(cfg_t *cfg, const char *filename)
 {
     FILE *fp;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST        = annotate.conf a.conf b.conf spdir check_confuse.h
+EXTRA_DIST        = annotate.conf a.conf b.conf rawinc.conf spdir check_confuse.h
 
 TESTS             = keyval
 TESTS            += suite_single

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,7 @@ TESTS            += setopt_ptr
 TESTS            += setmulti_reset
 TESTS            += print_filter
 TESTS            += modified_flag
+TESTS            += rawsec
 
 check_PROGRAMS    = $(TESTS)
 

--- a/tests/ignore_parm.c
+++ b/tests/ignore_parm.c
@@ -16,16 +16,97 @@ cfg_opt_t opts[] = {
 	CFG_END()
 };
 
-static int testconfig(const char *buf)
-{
-	cfg_t *cfg;
+/* One expected value to verify in the parsed structure.
+ * The path uses '.' to descend into sections
+ * '[n]' to pick an index (section instance or list element);
+ * value points to the expected value for the given type. */
+struct check {
+	cfg_type_t  type;
+	const char *path;
+	const void *value;
+};
 
-	cfg = cfg_init(opts, CFGF_IGNORE_UNKNOWN);
+static cfg_opt_t *resolve(cfg_t *cfg, const char *path, unsigned int *index)
+{
+	char name[128];
+
+	for (;;) {
+		size_t len = strcspn(path, ".[");
+		unsigned int idx = 0;
+
+		if (len == 0 || len >= sizeof(name))
+			return NULL;
+		memcpy(name, path, len);
+		name[len] = '\0';
+		path += len;
+
+		if (*path == '[') {
+			idx = (unsigned int)atoi(path + 1);
+			path = strchr(path, ']');
+			if (!path)
+				return NULL;
+			path++;
+		}
+
+		if (*path == '.') {
+			cfg = cfg_getnsec(cfg, name, idx);
+			if (!cfg)
+				return NULL;
+			path++;
+			continue;
+		}
+
+		if (*path != '\0')
+			return NULL;
+
+		*index = idx;
+		return cfg_getopt(cfg, name);
+	}
+}
+
+static int check_value(cfg_t *cfg, const struct check *c)
+{
+	unsigned int idx = 0;
+	cfg_opt_t *opt = resolve(cfg, c->path, &idx);
+
+	if (!opt)
+		return 0;
+
+	switch (c->type) {
+	case CFGT_INT:
+		return cfg_opt_getnint(opt, idx) == *(const long int *)c->value;
+	case CFGT_FLOAT:
+		return cfg_opt_getnfloat(opt, idx) == *(const double *)c->value;
+	case CFGT_BOOL:
+		return cfg_opt_getnbool(opt, idx) == *(const cfg_bool_t *)c->value;
+	case CFGT_STR: {
+		const char *s = cfg_opt_getnstr(opt, idx);
+
+		return s && strcmp(s, (const char *)c->value) == 0;
+	}
+	default:
+		return 0;
+	}
+}
+
+static int testconfig(const char *buf, const struct check *checks)
+{
+	cfg_t *cfg = cfg_init(opts, CFGF_IGNORE_UNKNOWN);
+
 	if (!cfg)
 		return 0;
 
-	if (cfg_parse_buf(cfg, buf) != CFG_SUCCESS)
+	if (cfg_parse_buf(cfg, buf) != CFG_SUCCESS) {
+		cfg_free(cfg);
 		return 0;
+	}
+
+	for (; checks && checks->path; checks++) {
+		if (!check_value(cfg, checks)) {
+			cfg_free(cfg);
+			return 0;
+		}
+	}
 
 	cfg_free(cfg);
 
@@ -35,36 +116,43 @@ static int testconfig(const char *buf)
 int main(void)
 {
 	/* Sanity check cases that don't need to ignore parameters. */
-	fail_unless(testconfig("parameter=5"));
+	fail_unless(testconfig("parameter=5",
+			       (struct check[]){ { CFGT_STR, "parameter", "5" }, { 0 } }));
 	fail_unless(testconfig("parameter=5\n"
 			       "section mysection {\n"
 			       "\tsection_parameter=1\n"
-			       "}"));
+			       "}",
+			       (struct check[]){ { CFGT_STR, "parameter", "5" },
+						 { CFGT_STR, "section[0].section_parameter", "1" },
+						 { 0 } }));
 
 	/* Ignore each type (no lists) */
-	fail_unless(testconfig("unknown_int=1"));
-	fail_unless(testconfig("unknown_string=\"hello\""));
-	fail_unless(testconfig("unknown_float=1.1"));
-	fail_unless(testconfig("unknown_bool=true"));
+	fail_unless(testconfig("unknown_int=1", NULL));
+	fail_unless(testconfig("unknown_string=\"hello\"", NULL));
+	fail_unless(testconfig("unknown_float=1.1", NULL));
+	fail_unless(testconfig("unknown_bool=true", NULL));
 
 	/* Ignore multiple parameters */
 	fail_unless(testconfig("unknown_one=1\n"
 			       "unknown_two=2\n"
-			       "unknown_three=3\n"));
+			       "unknown_three=3\n", NULL));
 
 	/* Test ignore parameters in a section */
 	fail_unless(testconfig("section mysection {\n"
 			       "\tunknown_section_parameter=1\n"
-			       "}"));
+			       "}", NULL));
 
-	/* Ignore unknown section, with unknown parameters */
+	/* Ignore unknown section, with unknown parameters.*/
 	fail_unless(testconfig("parameter=5\n"
 			       "unknown section {\n"
 			       "\tunknown_param=1\n"
 			       "\tunknown_list={1,2,3,4}\n"
 			       "}\n"
 			       "section hej { section_parameter = \"gnejs\" }\n"
-			       "parameter = \"ormbunke\""));
+			       "parameter = \"ormbunke\"",
+			       (struct check[]){ { CFGT_STR, "parameter", "ormbunke" },
+						 { CFGT_STR, "section[0].section_parameter", "gnejs" },
+						 { 0 } }));
 
 	return 0;
 }

--- a/tests/rawinc.conf
+++ b/tests/rawinc.conf
@@ -1,0 +1,2 @@
+included = yes
+sub { n = 1 }

--- a/tests/rawsec.c
+++ b/tests/rawsec.c
@@ -1,0 +1,107 @@
+#include "check_confuse.h"
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * A raw section (CFGT_RAWSEC) captures a chunk of confuse configuration
+ * verbatim so its owner can parse it later (deferred).  The body is walked
+ * with confuse's own mini discard parser
+ */
+
+/*
+ * Verbatim capture, exercising every shape the mini discard parser walks.
+ */
+#define RAW_BODY \
+	"\n" \
+	"    host = \"1.2.3.4\"\n" \
+	"    urls = {http://127.0.0.1:56666/}\n" \
+	"    items += { extra }\n" \
+	"    hook(\"do\", \"stuff\")\n" \
+	"    note = \"a } b\"\n" \
+	"    tls {\n" \
+	"        verify = yes\n" \
+	"    }\n" \
+	"    route \"main\" {\n" \
+	"        target = x\n" \
+	"    }\n"
+
+static void check_verbatim(void)
+{
+	cfg_opt_t opts[] = {
+		CFG_RAWSEC("mod", CFGF_NONE),
+		CFG_END()
+	};
+	cfg_t *cfg = cfg_init(opts, 0);
+
+	fail_unless(cfg != NULL);
+	fail_unless(cfg_parse_buf(cfg, "mod {" RAW_BODY "}") == CFG_SUCCESS);
+	fail_unless(cfg_getraw(cfg_getsec(cfg, "mod")) != NULL);
+	fail_unless(strcmp(cfg_getraw(cfg_getsec(cfg, "mod")), RAW_BODY) == 0);
+	cfg_free(cfg);
+}
+
+/*
+ * Deferred parse: capture a module's config, then parse the captured text
+ * later with the module's own schema.
+ */
+static void check_deferred(void)
+{
+	cfg_opt_t outer[] = {
+		CFG_RAWSEC("mod", CFGF_TITLE | CFGF_MULTI),
+		CFG_END()
+	};
+	cfg_opt_t inner[] = {
+		CFG_STR("host", "", CFGF_NONE),
+		CFG_INT("port", 0, CFGF_NONE),
+		CFG_END()
+	};
+	cfg_t *cfg, *sub;
+	const char *raw;
+
+	cfg = cfg_init(outer, 0);
+	fail_unless(cfg_parse_buf(cfg,
+		"mod \"db\" { host = \"1.2.3.4\" port = 5432 }") == CFG_SUCCESS);
+
+	raw = cfg_getraw(cfg_gettsec(cfg, "mod", "db"));
+	fail_unless(raw != NULL);
+
+	sub = cfg_init(inner, 0);
+	fail_unless(cfg_parse_buf(sub, raw) == CFG_SUCCESS);
+	fail_unless(strcmp(cfg_getstr(sub, "host"), "1.2.3.4") == 0);
+	fail_unless(cfg_getint(sub, "port") == 5432);
+	cfg_free(sub);
+	cfg_free(cfg);
+}
+
+/* Several titled raw sections. */
+static void check_multi_titled(void)
+{
+	cfg_opt_t opts[] = {
+		CFG_RAWSEC("block", CFGF_TITLE | CFGF_MULTI),
+		CFG_END()
+	};
+	cfg_t *cfg = cfg_init(opts, 0);
+
+	fail_unless(cfg_parse_buf(cfg,
+		"block \"a\" { x = 1 } block \"b\" { y = 2 }") == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "block") == 2);
+	fail_unless(strcmp(cfg_getraw(cfg_gettsec(cfg, "block", "a")), " x = 1 ") == 0);
+	fail_unless(strcmp(cfg_getraw(cfg_gettsec(cfg, "block", "b")), " y = 2 ") == 0);
+	cfg_free(cfg);
+}
+
+int main(void)
+{
+	check_verbatim();
+	check_deferred();
+	check_multi_titled();
+
+	return 0;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/tests/rawsec.c
+++ b/tests/rawsec.c
@@ -90,11 +90,41 @@ static void check_multi_titled(void)
 	cfg_free(cfg);
 }
 
+/*
+ * With CFGF_USE_INCLUDE_FUNCTION an include() inside a raw body is expanded
+ * into the captured text: the included file's content replaces the call.
+ */
+static void check_include(void)
+{
+	cfg_opt_t opts[] = {
+		CFG_RAWSEC("mod", CFGF_USE_INCLUDE_FUNCTION),
+		CFG_END()
+	};
+	cfg_t *cfg = cfg_init(opts, 0);
+	const char *raw;
+
+	fail_unless(cfg_parse_buf(cfg,
+		"mod {\n"
+		"    before = 1\n"
+		"    include(\"" SRC_DIR "/rawinc.conf\")\n"
+		"    after = 2\n"
+		"}") == CFG_SUCCESS);
+
+	raw = cfg_getraw(cfg_getsec(cfg, "mod"));
+	fail_unless(raw != NULL);
+	fail_unless(strstr(raw, "before = 1") != NULL);
+	fail_unless(strstr(raw, "included = yes") != NULL);
+	fail_unless(strstr(raw, "after = 2") != NULL);
+	fail_unless(strstr(raw, "include(") == NULL);
+	cfg_free(cfg);
+}
+
 int main(void)
 {
 	check_verbatim();
 	check_deferred();
 	check_multi_titled();
+	check_include();
 
 	return 0;
 }


### PR DESCRIPTION
### Motivation

While integrating libConfuse into a larger application we needed deferred configuration for pluggable components. Each component ships its own configuration schema, but the top‑level parser neither knows — nor should know — what that schema looks like.

The idea is to let the top‑level parser recognize a component's configuration block, validate that it is well‑formed, but not fully parse it — instead hand it over as text, so the component can parse it later against its own schema.

### What this adds

1. A new option type CFGT_RAWSEC (macro CFG_RAWSEC).
The body between { and the matching } is captured verbatim instead of being parsed:

- The body is still walked by confuse's own mini discard parser, so it is validated for well‑formedness (balanced braces, valid tokens) — a broken block is a parse error
- CFGF_TITLE (named raw sections) and CFGF_MULTI are supported via the existing section machinery.

2. A new flag CFGF_USE_INCLUDE_FUNCTION (second commit) that adds an include() function to a section's options. For a raw section, include() is expanded into the captured body (the call text is replaced by the included file's content, recursively).

### Example

cfg_opt_t opts[] = {
    CFG_RAWSEC("component", CFGF_MULTI | CFGF_TITLE),
    CFG_END()
};
/* config:  component "db" { host = "1.2.3.4" port = 5432 } */

cfg_t *db = cfg_gettsec(cfg, "component", "db");
const char *raw = cfg_getraw(db);   /* ' host = "1.2.3.4" port = 5432 ' */

### Notes

- The second commit is optional; it's tied to the first commit but implements separate functionality. If needed, it can be split into multiple pull requests.

### Tests

Adds tests/rawsec.c: covers all changed functionality