### PR TITLE
Guard cfg_parse_internal() against unbounded section nesting (stack overflow, #182)

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -81,6 +81,11 @@ static int cfg_print_pff_indent(cfg_t *cfg, FILE *fp,
 #define STATE_EOF -1
 #define STATE_ERROR 1
 
+/* Guard against stack exhaustion from deeply/infinitely nested sections,
+ * similar in spirit to MAX_INCLUDE_DEPTH in lexer.l for include() nesting.
+ */
+#define CFG_MAX_NESTING_DEPTH 500
+
 #ifndef HAVE_FMEMOPEN
 extern FILE *fmemopen(void *buf, size_t size, const char *type);
 #endif
@@ -1400,6 +1405,13 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 		state = force_state;
 	if (force_opt)
 		opt = force_opt;
+
+	if (level > CFG_MAX_NESTING_DEPTH) {
+		cfg_error(cfg, _("too deeply nested sections (max %d), "
+				 "bailing out to avoid stack exhaustion"),
+			  CFG_MAX_NESTING_DEPTH);
+		goto error;
+	}
 
 	while (1) {
 		int tok = cfg_yylex(cfg);


### PR DESCRIPTION
## What

`cfg_parse_internal()` recurses once per nested section (`CFGT_SEC`)
and once per `CFGF_IGNORE_UNKNOWN` "unknown key treated as a nested
block" branch, with no limit on nesting depth. A config buffer with
enough nested braces drives this recursion until the process stack is
exhausted, crashing the process with `SIGSEGV` instead of returning a
normal parse error. Reported in #182.

This is the same class of problem the existing `MAX_INCLUDE_DEPTH`
guard in `src/lexer.l` already protects against for `include()`
nesting — that guard just doesn't cover section/unknown-block nesting.

## Fix

Add a `CFG_MAX_NESTING_DEPTH` (500) check at the top of
`cfg_parse_internal()`. Once `level` exceeds that, it calls
`cfg_error()` and returns `STATE_ERROR` through the function's
existing error path, instead of recursing further.

## Testing

Verified locally (standalone repro linking `confuse.c`/generated
`lexer.c`, not via the `make check` suite) by feeding
`cfg_parse_buf()` a buffer of deeply nested `unk{...}` blocks under
`CFGF_IGNORE_UNKNOWN` with an empty `opts[]`:

- Unpatched (current `master`): returns cleanly at 1,000 and 25,000
  levels of nesting, but segfaults (`SIGSEGV`) once nesting reaches
  ~30,000 levels.
- Patched: returns a controlled parse error at 1,000 levels and above,
  and no longer crashes even at 2,000,000 levels of nesting.
- Normal, shallow nesting (well under 500 levels) still parses
  successfully and is unaffected — checked both with the same repro
  harness and with a small multi-section (`CFGF_MULTI`) config using
  real string/int options, which parses identically before and after
  the patch.