### PR TITLE
Preserve defaults when cfg_addlist() appends

### DIFF
--- a/src/confuse.c
+++ b/src/confuse.c
@@ -2434,6 +2434,7 @@ DLLIMPORT int cfg_addlist(cfg_t *cfg, const char *name, unsigned int nvalues, ..
 		return CFG_FAIL;
 	}
 
+	opt->flags &= ~CFGF_RESET;
 	va_start(ap, nvalues);
 	cfg_addlist_internal(opt, nvalues, ap);
 	va_end(ap);

--- a/tests/suite_list.c
+++ b/tests/suite_list.c
@@ -98,6 +98,13 @@ static void list_integer_test(void)
 
 	fail_unless(cfg_getint(cfg, "integer") == 4711);
 	fail_unless(cfg_getnint(cfg, "integer", 1) == 123456789);
+	fail_unless(cfg_parse_buf(cfg, "") == CFG_SUCCESS);
+	fail_unless(cfg_addlist(cfg, "integer", 2, 11, 22) == CFG_SUCCESS);
+	fail_unless(cfg_size(cfg, "integer") == 4);
+	fail_unless(cfg_getnint(cfg, "integer", 0) == 4711);
+	fail_unless(cfg_getnint(cfg, "integer", 1) == 123456789);
+	fail_unless(cfg_getnint(cfg, "integer", 2) == 11);
+	fail_unless(cfg_getnint(cfg, "integer", 3) == 22);
 	buf = "integer = {-46}";
 	fail_unless(cfg_parse_buf(cfg, buf) == CFG_SUCCESS);
 	fail_unless(cfg_size(cfg, "integer") == 1);


### PR DESCRIPTION
## Summary

`cfg_init()` marks default lists with `CFGF_RESET` so an assignment can replace them. `cfg_addlist()` left that flag set, causing its first appended value to free the defaults after an empty configuration was parsed.

Clear the flag before appending, matching the parser's existing `+=` path. Add a regression covering default integers followed by an empty parse and an API append.

## Testing

- focused `suite_list` regression fails before the fix and passes after it
- GCC 13 ASan and UBSan focused run
- MinGW GCC 8 `-Wall -Wextra -Wpedantic -Werror` compilation

Fixes #179